### PR TITLE
Add nonce-based CSP for inline scripts security

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
+import { headers } from "next/headers";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { AuthShell } from "@/components/layout/auth-shell";
@@ -28,15 +29,17 @@ export const viewport: Viewport = {
 // Inline script to apply theme before first paint (prevents FOUC)
 const themeScript = `(function(){try{var t=localStorage.getItem("healthlog-theme");var c=(t==="light"||t==="dark")?t:(window.matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light");document.documentElement.classList.add(c)}catch(e){document.documentElement.classList.add("dark")}})()`;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const nonce = (await headers()).get("x-nonce") ?? "";
+
   return (
     <html lang="de" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>
         <Providers>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
   void request;
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
   const response = NextResponse.next();
 
   // Security headers
@@ -16,9 +17,10 @@ export function middleware(request: NextRequest) {
   // CSP — permissive in dev, strict in production
   const isDev = process.env.NODE_ENV === "development";
   const csp = isDev
-    ? "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self';"
-    : "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.openai.com https://wbsapi.withings.net; font-src 'self';";
+    ? `default-src 'self'; script-src 'self' 'nonce-${nonce}' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self';`
+    : `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://api.openai.com https://wbsapi.withings.net; font-src 'self';`;
   response.headers.set("Content-Security-Policy", csp);
+  response.headers.set("x-nonce", nonce);
 
   // HSTS in production
   if (!isDev) {


### PR DESCRIPTION
## Summary
Implement Content Security Policy (CSP) nonce-based protection for inline scripts to improve security posture while maintaining functionality across development and production environments.

## Key Changes
- **Middleware (`src/middleware.ts`)**:
  - Generate a cryptographically random nonce on each request using `crypto.randomUUID()`
  - Include the nonce in CSP headers for script-src directive
  - Pass the nonce to the client via `x-nonce` response header
  - Update CSP to use nonce instead of `'unsafe-inline'` for scripts in production

- **Root Layout (`src/app/layout.tsx`)**:
  - Convert `RootLayout` to an async component to retrieve the nonce from request headers
  - Apply the nonce to the theme initialization inline script via the `nonce` attribute
  - Maintain development flexibility with `'unsafe-eval'` and `'unsafe-inline'` fallbacks

## Implementation Details
- The nonce is generated in middleware and passed through response headers, then retrieved in the layout component
- Development mode retains `'unsafe-eval'` and `'unsafe-inline'` for better DX while still using nonce
- Production mode enforces strict CSP with only `'self'` and nonce-based inline scripts
- This approach prevents XSS attacks while allowing the theme script to execute without blocking
