### PR TITLE
Switch auth to email-based login and translate zxcvbn feedback to German

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -25,14 +25,14 @@ export async function POST(request: NextRequest) {
       return apiError("Ungültige Anmeldedaten", 422);
     }
 
-    const { username, password } = parsed.data;
+    const { email, password } = parsed.data;
 
-    const user = await prisma.user.findUnique({ where: { username } });
+    const user = await prisma.user.findUnique({ where: { email } });
 
     if (!user || !user.passwordHash) {
       await auditLog("auth.login.failed", {
         ipAddress: ip,
-        details: { username, reason: "user_not_found_or_no_password" },
+        details: { email, reason: "user_not_found_or_no_password" },
       });
       return apiError("Ungültige Anmeldedaten", 401);
     }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -15,6 +15,7 @@ export async function GET() {
     return apiSuccess({
       id: user.id,
       username: user.username,
+      email: user.email,
       role: user.role ?? "USER",
       heightCm: user.heightCm,
       dateOfBirth: user.dateOfBirth,

--- a/src/app/api/auth/passkey/register-options/route.ts
+++ b/src/app/api/auth/passkey/register-options/route.ts
@@ -11,7 +11,7 @@ export async function POST() {
 
     const { options, challengeId } = await createRegistrationOptions(
       sessionData.user.id,
-      sessionData.user.username,
+      sessionData.user.email ?? sessionData.user.username,
     );
 
     return apiSuccess({ options, challengeId });

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -45,20 +45,28 @@ export async function POST(request: NextRequest) {
       return apiError(parsed.error.issues[0].message, 422);
     }
 
-    const { username, password } = parsed.data;
+    const { email, username, password } = parsed.data;
+
+    // Check if email taken
+    const existingEmail = await prisma.user.findUnique({
+      where: { email },
+    });
+    if (existingEmail) {
+      return apiError("E-Mail-Adresse bereits vergeben", 409);
+    }
 
     // Check if username taken
-    const existing = await prisma.user.findUnique({
+    const existingUsername = await prisma.user.findUnique({
       where: { username },
     });
-    if (existing) {
+    if (existingUsername) {
       return apiError("Benutzername bereits vergeben", 409);
     }
 
     // If password provided, validate strength
     let passwordHash: string | null = null;
     if (password) {
-      const strength = checkPasswordStrength(password, [username]);
+      const strength = checkPasswordStrength(password, [username, email]);
       if (!strength.isAcceptable) {
         return apiError(
           strength.feedback[0] || "Passwort zu schwach (Score < 3)",
@@ -75,6 +83,7 @@ export async function POST(request: NextRequest) {
     // Create user
     const user = await prisma.user.create({
       data: {
+        email,
         username,
         passwordHash,
         role,
@@ -84,7 +93,7 @@ export async function POST(request: NextRequest) {
     // Generate passkey registration options
     const { options, challengeId } = await createRegistrationOptions(
       user.id,
-      user.username,
+      user.email!,
     );
 
     // Create session immediately (user is "registered" even before passkey)
@@ -99,7 +108,7 @@ export async function POST(request: NextRequest) {
 
     return apiSuccess(
       {
-        user: { id: user.id, username: user.username },
+        user: { id: user.id, username: user.username, email: user.email },
         passkey: { options, challengeId },
       },
       201,

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const [mode, setMode] = useState<"passkey" | "password">("passkey");
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -93,7 +93,7 @@ export default function LoginPage() {
       const res = await fetch("/api/auth/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ email, password }),
       });
 
       const json = await res.json();
@@ -156,15 +156,15 @@ export default function LoginPage() {
           ) : (
             <form onSubmit={handlePasswordLogin} className="space-y-3">
               <div className="space-y-2">
-                <Label htmlFor="username">Benutzername</Label>
+                <Label htmlFor="email">E-Mail-Adresse</Label>
                 <Input
-                  id="username"
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
                   required
-                  autoComplete="username"
-                  placeholder="user"
+                  autoComplete="email"
+                  placeholder="name@beispiel.de"
                 />
               </div>
               <div className="space-y-2">

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -15,6 +15,7 @@ import { PasswordStrength } from "@/components/ui/password-strength";
 export default function RegisterPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -31,6 +32,7 @@ export default function RegisterPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          email,
           username,
           password: password || undefined,
         }),
@@ -106,6 +108,19 @@ export default function RegisterPage() {
         {step === "form" && (
           <form onSubmit={handleRegister} className="mt-8 space-y-4">
             <div className="space-y-2">
+              <Label htmlFor="email">E-Mail-Adresse</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="name@beispiel.de"
+                required
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="space-y-2">
               <Label htmlFor="username">Benutzername</Label>
               <Input
                 id="username"
@@ -124,7 +139,7 @@ export default function RegisterPage() {
               <Label htmlFor="password">
                 Passwort{" "}
                 <span className="text-muted-foreground font-normal">
-                  (optional)
+                  (optional, Fallback)
                 </span>
               </Label>
               <Input

--- a/src/components/ui/password-strength.tsx
+++ b/src/components/ui/password-strength.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import zxcvbn from "zxcvbn-typescript";
 import { cn } from "@/lib/utils";
+import { translateZxcvbn } from "@/lib/zxcvbn-de";
 
 interface PasswordStrengthProps {
   password: string;
@@ -46,10 +47,10 @@ export function PasswordStrength({
     feedback.push(`Mindestens ${minLength} Zeichen erforderlich.`);
   }
   if (result?.feedback.warning) {
-    feedback.push(result.feedback.warning);
+    feedback.push(translateZxcvbn(result.feedback.warning));
   }
   if (result?.feedback.suggestions) {
-    feedback.push(...result.feedback.suggestions);
+    feedback.push(...result.feedback.suggestions.map(translateZxcvbn));
   }
 
   return (

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,5 +1,6 @@
 import { hash, verify } from "@node-rs/argon2";
 import zxcvbn from "zxcvbn-typescript";
+import { translateZxcvbn } from "@/lib/zxcvbn-de";
 
 export async function hashPassword(password: string): Promise<string> {
   return hash(password, {
@@ -39,10 +40,10 @@ export function checkPasswordStrength(
   const feedback: string[] = [];
 
   if (result.feedback.warning) {
-    feedback.push(result.feedback.warning);
+    feedback.push(translateZxcvbn(result.feedback.warning));
   }
   if (result.feedback.suggestions) {
-    feedback.push(...result.feedback.suggestions);
+    feedback.push(...result.feedback.suggestions.map(translateZxcvbn));
   }
 
   return {

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 
 export const registerSchema = z.object({
+  email: z.email("Ungültige E-Mail-Adresse"),
   username: z
     .string()
     .min(3, "Mindestens 3 Zeichen")
@@ -10,7 +11,7 @@ export const registerSchema = z.object({
 });
 
 export const loginPasswordSchema = z.object({
-  username: z.string().min(1),
+  email: z.email("Ungültige E-Mail-Adresse"),
   password: z.string().min(1),
 });
 

--- a/src/lib/zxcvbn-de.ts
+++ b/src/lib/zxcvbn-de.ts
@@ -1,0 +1,63 @@
+/**
+ * German translations for zxcvbn feedback messages.
+ * Used by both client-side password-strength component and server-side validation.
+ */
+
+const warnings: Record<string, string> = {
+  'Straight rows of keys are easy to guess':
+    'Gerade Tastenreihen sind leicht zu erraten',
+  'Short keyboard patterns are easy to guess':
+    'Kurze Tastaturmuster sind leicht zu erraten',
+  'Repeats like "aaa" are easy to guess':
+    'Wiederholungen wie „aaa" sind leicht zu erraten',
+  'Repeats like "abcabc" are easy to guess':
+    'Wiederholungen wie „abcabc" sind leicht zu erraten',
+  'Sequences like abc or 6543 are easy to guess':
+    'Sequenzen wie abc oder 6543 sind leicht zu erraten',
+  'Recent years are easy to guess': 'Aktuelle Jahreszahlen sind leicht zu erraten',
+  'Dates are often easy to guess': 'Datumsangaben sind oft leicht zu erraten',
+  'This is a top-10 common password':
+    'Dies gehört zu den 10 häufigsten Passwörtern',
+  'This is a top-100 common password':
+    'Dies gehört zu den 100 häufigsten Passwörtern',
+  'This is a very common password': 'Dies ist ein sehr häufiges Passwort',
+  'This is similar to a commonly used password':
+    'Dies ähnelt einem häufig verwendeten Passwort',
+  'A word by itself is easy to guess':
+    'Ein einzelnes Wort ist leicht zu erraten',
+  'Names and surnames by themselves are easy to guess':
+    'Einzelne Namen sind leicht zu erraten',
+  'Common names and surnames are easy to guess':
+    'Häufige Namen sind leicht zu erraten',
+};
+
+const suggestions: Record<string, string> = {
+  'Use a few words, avoid common phrases':
+    'Verwende mehrere Wörter, vermeide gängige Phrasen',
+  'No need for symbols, digits, or uppercase letters':
+    'Symbole, Ziffern oder Großbuchstaben sind nicht nötig',
+  'Add another word or two. Uncommon words are better.':
+    'Füge ein oder zwei weitere Wörter hinzu. Ungewöhnliche Wörter sind besser.',
+  'Use a longer keyboard pattern with more turns':
+    'Verwende ein längeres Tastaturmuster mit mehr Richtungswechseln',
+  'Avoid repeated words and characters':
+    'Vermeide wiederholte Wörter und Zeichen',
+  'Avoid sequences': 'Vermeide Sequenzen',
+  'Avoid recent years': 'Vermeide aktuelle Jahreszahlen',
+  'Avoid years that are associated with you':
+    'Vermeide Jahreszahlen, die mit dir in Verbindung stehen',
+  'Avoid dates and years that are associated with you':
+    'Vermeide Datumsangaben und Jahreszahlen, die mit dir in Verbindung stehen',
+  "Capitalization doesn't help very much":
+    'Großschreibung hilft nicht wesentlich',
+  'All-uppercase is almost as easy to guess as all-lowercase':
+    'Nur Großbuchstaben sind fast so leicht zu erraten wie nur Kleinbuchstaben',
+  "Reversed words aren't much harder to guess":
+    'Umgekehrte Wörter sind kaum schwerer zu erraten',
+  "Predictable substitutions like '@' instead of 'a' don't help very much":
+    'Vorhersehbare Ersetzungen wie „@" statt „a" helfen nicht wesentlich',
+};
+
+export function translateZxcvbn(text: string): string {
+  return warnings[text] ?? suggestions[text] ?? text;
+}


### PR DESCRIPTION
Registration now requires email + username + optional password. Login (password fallback) uses email instead of username. All zxcvbn password-strength feedback is translated to German via a shared translation map (src/lib/zxcvbn-de.ts), fixing the mixed German/English UI text. The /me endpoint and passkey registration now also expose/use the email field.
