### PR TITLE
Add migration for missing database columns (fix Prisma P2022 error)

### DIFF
--- a/prisma/migrations/0003_add_missing_columns/migration.sql
+++ b/prisma/migrations/0003_add_missing_columns/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable: Add missing columns to users
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "gender" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "telegram_bot_token" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "telegram_chat_id" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "telegram_enabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "withings_client_id_encrypted" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "withings_client_secret_encrypted" TEXT;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "onboarding_completed_at" TIMESTAMP(3);
+
+-- AlterTable: Add missing dose column to medication_schedules
+ALTER TABLE "medication_schedules" ADD COLUMN IF NOT EXISTS "dose" TEXT;
+
+-- AlterEnum: Add IMPORT to intake_source
+ALTER TYPE "intake_source" ADD VALUE IF NOT EXISTS 'IMPORT';


### PR DESCRIPTION
The Prisma schema defined columns on the users table (gender, telegram fields, Withings client credentials, onboarding timestamp), the medication_schedules table (dose), and the intake_source enum (IMPORT) that were never added via migrations. This caused P2022 "column does not exist" errors on any query touching the users table, including registration.
