### PR TITLE
feat(ci): Phase 2 — multi-arch Docker image to GHCR + supply chain (#88)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,78 @@
+name: Build & Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# Cancel in-progress runs when a new commit is pushed to the same ref.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build & push multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Skip login on PRs from forks — they don't have package:write.
+      # Image is built but not pushed in that case.
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=short
+          labels: |
+            org.opencontainers.image.title=HealthLog
+            org.opencontainers.image.description=Self-hosted health-tracking PWA
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Most health apps lock your data behind proprietary clouds, push subscriptions, a
 
 ## Quick Start
 
-Plan ~5 minutes for a working install. The bundled `docker-compose.yml` builds the app from source — pre-built images on GHCR are coming in a separate release.
+Plan ~5 minutes for a working install. The bundled `docker-compose.yml` pulls a pre-built multi-arch image (`linux/amd64` + `linux/arm64`) from [GitHub Container Registry](https://github.com/MBombeck/HealthLog/pkgs/container/healthlog); no build step required for self-hosters. Contributors who want to test local changes can `docker compose up --build`.
 
 ```bash
 git clone https://github.com/MBombeck/HealthLog.git

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 Only the latest release on the `main` branch is actively supported with security updates.
 
 | Version | Supported |
-|---------|-----------|
+| ------- | --------- |
 | Latest  | Yes       |
 | Older   | No        |
 
@@ -59,3 +59,17 @@ HealthLog is designed with security as a core principle:
 - **Proxy-level route protection** via `proxy.ts` (session cookie validation on all non-public paths)
 
 For more details, see the [security documentation](https://docs.healthlog.dev/security/overview/).
+
+## Supply Chain
+
+HealthLog Docker images are built and published from this repository's CI:
+
+- **Source**: [`.github/workflows/docker-publish.yml`](.github/workflows/docker-publish.yml) — runs on every push to `main` and every `v*` tag
+- **Registry**: [`ghcr.io/mbombeck/healthlog`](https://github.com/MBombeck/HealthLog/pkgs/container/healthlog)
+- **Architectures**: `linux/amd64` and `linux/arm64`
+- **Provenance attestation**: each image carries a [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance) statement linking it back to the GitHub Actions run, the commit SHA, and the workflow definition
+- **SBOM**: each image includes a [Software Bill of Materials](https://docs.docker.com/build/metadata/attestations/sbom/) you can inspect with `docker buildx imagetools inspect ghcr.io/mbombeck/healthlog:latest --format '{{ json .SBOM }}'`
+
+To pin to a specific version in production, replace `:latest` with the released tag in your `docker-compose.yml`, e.g. `ghcr.io/mbombeck/healthlog:1.2.0`. Pinning is recommended for self-hosters who want explicit control over upgrades.
+
+If you discover a tampered or unexpected image, please report it as a vulnerability via the email above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 services:
   app:
+    # Pre-built multi-arch images are published to GHCR by
+    # .github/workflows/docker-publish.yml on every push to main and on
+    # tagged releases. Pin to a specific version in production:
+    # e.g. ghcr.io/mbombeck/healthlog:1.2.0
+    image: ghcr.io/mbombeck/healthlog:latest
+    # Fallback build context: if the image is not yet in the registry,
+    # or you want to test local changes, run `docker compose up --build`.
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary

Phase 2 of the [audit plan](./docs/audit/2026-04-26-PLAN.md) — the supply-chain side of Issue #88. Stacked on top of [Phase 1 (#102)](https://github.com/MBombeck/HealthLog/pull/102); will auto-retarget to `main` when Phase 1 merges.

- **`.github/workflows/docker-publish.yml`** — multi-arch (amd64+arm64) build via buildx, push to GHCR on main + tags, PR builds without push, GHA cache, SLSA provenance + SBOM attestations on every image.
- **`docker-compose.yml`** — primary `image: ghcr.io/mbombeck/healthlog:latest` plus `build:` fallback so contributors can still `docker compose up --build`.
- **`SECURITY.md`** — new Supply Chain section: where images come from, how to verify provenance/SBOM, how to pin a release.
- **`README.md`** — Quick Start clarifies no build needed for self-hosters.

The first run of the workflow on `main` will publish the image. Until then, `docker compose up` falls back to the local build, so we don't break anyone in the gap.

## Companion PRs (single-source-of-truth for setup docs)

Phase 2 includes mirror changes in:
- **healthlog-docs** — `installation.mdx` becomes the canonical Quick Start (mirrors this repo's compose), `self-hosting/docker.mdx` slimmed to image internals + ops notes only. PR pending.
- **healthlog-landing** — terminal block updated to include the secrets-generation step (was missing). PR pending.

## What this PR explicitly does *not* do

- No automatic GHCR package visibility change. After the workflow's first publish, the package is private by default; you'll need to flip it to public in the GHCR settings UI for unauthenticated pulls to work. I'd suggest doing that after one successful workflow run on main.
- Does not change CI's `continue-on-error: true` on ESLint/typecheck — that's Phase 5.
- Does not address #89 — Phase 3.

## Test plan

CI:

- [ ] On PR open, `Build & Publish Docker Image` workflow should run and **build only** (no push, no GHCR auth required).
- [ ] After merge to `main`, the same workflow should run and **push** `ghcr.io/mbombeck/healthlog:latest` plus a `sha-<short>` tag.
- [ ] `docker buildx imagetools inspect ghcr.io/mbombeck/healthlog:latest` should show two manifests (amd64, arm64), provenance, and SBOM.

Local:

```bash
gh pr checkout <this-pr-number>
docker compose config       # validates structure
docker compose up --build   # builds locally — should still work for contributors
```

After workflow runs and image is public:

```bash
docker compose pull && docker compose up -d  # pulls instead of builds
```

## Issue mapping

- Closes 3 of the remaining 7 sub-points in #88: GHCR image push, image pull instructions, supply chain.
- Companion docs PR closes the remaining 4 (doc consolidation, single-source-of-truth, README + docs alignment).
