### PR TITLE
feat: headless-client API surface (Bearer auth, idempotency, aggregator endpoints, PDF report)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+# Gitleaks configuration. Extends the built-in default ruleset and adds
+# a project-specific allowlist for false-positives that gitleaks 8.x flags
+# as "generic-api-key" inside test fixtures.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Project-wide ignores for test fixtures and known non-secret tokens"
+
+paths = [
+  # All test files contain hardcoded fake tokens / idempotency-keys.
+  '''(^|/)__tests__/''',
+  '''\.test\.ts$''',
+  # OpenAPI spec contains example tokens (`hlk_example…`) used to document the schema.
+  '''^docs/api/openapi\.yaml$''',
+]
+
+# Substring matches — anything matching is treated as non-secret regardless of file.
+regexes = [
+  # Idempotency-Key request-header values are random UUIDs / opaque strings,
+  # not secrets. The header name itself just trips the generic-api-key rule.
+  '''idempotency-key''',
+  # Allow the placeholder prefix used in OpenAPI examples + docs.
+  '''hlk_example''',
+]
+
+# Specific commit fingerprints from prior false-positive findings (kept for reproducibility).
+# Empty by default; populate via `gitleaks detect --report-path` if a future regression
+# triggers the same false-positive on a stable commit hash.
+stopwords = []

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,76 @@
+# HealthLog API Spec
+
+`openapi.yaml` is the canonical OpenAPI 3.1 description for the HealthLog
+Next.js API. It is the source of truth for the native iOS client's
+DTO codegen.
+
+## Preview locally
+
+Open an interactive Redoc preview in your browser:
+
+```bash
+npx @redocly/cli preview docs/api/openapi.yaml
+```
+
+Generate static HTML for sharing:
+
+```bash
+npx @redocly/cli build-docs docs/api/openapi.yaml --output docs/api/index.html
+```
+
+## Validate
+
+```bash
+npx @redocly/cli lint docs/api/openapi.yaml
+```
+
+The spec is expected to be lint-clean (errors = 0). Some warnings are
+intentional:
+
+- `no-server-example.com` — `http://localhost:3000` is the dev server.
+- `operation-2xx-response` / `operation-4xx-response` — webhook + redirect
+  endpoints intentionally omit one or the other.
+- `no-unused-components` — `ReminderPhase` is exposed for client codegen
+  even though no path response references it directly.
+
+## Layout
+
+- **`info`** — title, version (mirrored from `package.json`), description.
+- **`servers`** — production `https://healthlog.bombeck.io` plus
+  `http://localhost:3000` for local development.
+- **`tags`** — domain groupings (`Auth`, `Measurements`, `Medications`,
+  `Mood`, `Dashboard`, `Insights`, `Achievements`, `DoctorReport`,
+  `Integrations`, `User`, `Tokens`, `Notifications`, `Onboarding`,
+  `Health`, `Settings`, `Analytics`, `Export`, `AuditLog`, `Feedback`,
+  `BugReport`, `Monitoring`, `Webhooks`, `Ingest`, `Admin`).
+- **`securitySchemes`**:
+  - `bearerAuth` — long-lived `hlk_*` API tokens issued via `POST /api/tokens`.
+    Required on `/api/ingest/medication`.
+  - `sessionCookie` — HttpOnly `healthlog_session` cookie set by the
+    password and passkey login flows. Used by the web app and any iOS
+    client running inside a web view.
+- **`components.schemas`** — DTOs for all routes plus the underlying
+  Prisma models (e.g. `Measurement`, `Medication`, `MedicationIntakeEvent`,
+  `MoodEntry`, `User`, `DashboardLayout`, `ApiEnvelope`, `ApiError`).
+- **`paths`** — all routes from `src/app/api/**/route.ts`, including
+  the `/api/admin/*` family which is tagged `Admin` and marked internal.
+
+## Conventions
+
+- Successful responses use the envelope `{ data, error: null }`.
+- Error responses use the envelope `{ data: null, error: '<message>' }`.
+- Pagination uses `limit` + `offset` query parameters and a
+  `meta: { total, limit, offset }` block on the response.
+- All timestamps are ISO 8601 / RFC 3339 (`format: date-time`) in UTC.
+- IDs are CUIDs (opaque strings).
+
+## Updating the spec
+
+When adding or changing routes:
+
+1. Update the relevant route handler under `src/app/api/**/route.ts`.
+2. Mirror the change in `openapi.yaml`. Keep `operationId` camelCase and
+   stable — the iOS codegen keys off it.
+3. Run `npx @redocly/cli lint docs/api/openapi.yaml` and resolve all
+   errors. Warnings are tolerated when documented above.
+4. Bump `info.version` if the change is breaking for clients.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,4960 @@
+openapi: 3.1.0
+
+info:
+  title: HealthLog API
+  version: 1.3.0
+  description: |
+    REST API for HealthLog — a personal health-tracking PWA covering weight,
+    blood pressure, pulse, mood, medication compliance, blood glucose, and
+    sleep. The same API powers the Next.js web client and the native iOS
+    client.
+
+    ## Authentication
+
+    All non-public endpoints accept either a session cookie (`healthlog_session`,
+    obtained via password login or passkey verification) or a long-lived Bearer
+    token (`Authorization: Bearer hlk_...`) issued via `/api/tokens`. The two
+    schemes are interchangeable on user endpoints — clients pick whichever
+    suits them (cookies for the web app, Bearer for the iOS client and
+    machine-to-machine integrations). Admin endpoints (`/api/admin/*`) accept
+    only the session cookie; Bearer tokens never elevate to admin.
+
+    The API uses an envelope response shape: `{ data, error }`. On success,
+    `data` carries the payload and `error` is `null`. On failure, `data` is
+    `null` and `error` is a human-readable message.
+
+    ## Conventions
+
+    - All timestamps are ISO 8601 (`date-time`) in UTC.
+    - All numeric IDs are CUIDs (opaque strings).
+    - Pagination uses `limit` + `offset` query parameters; responses include
+      a `meta: { total, limit, offset }` block.
+    - Rate limiting is applied per-IP or per-user on auth, ingest, export,
+      AI, and bug-report endpoints. Exceeding the budget yields a `429`.
+
+    ## Admin endpoints
+
+    Routes under `/api/admin/*` are tagged `Admin` and are intended for the
+    internal admin UI only. iOS clients should not consume them.
+  contact:
+    name: HealthLog
+    url: https://healthlog.bombeck.io
+  license:
+    name: MIT
+    url: https://github.com/MBombeck/healthlog/blob/main/LICENSE
+
+servers:
+  - url: https://healthlog.bombeck.io
+    description: Production
+  - url: http://localhost:3000
+    description: Local development
+
+tags:
+  - name: Auth
+    description: Registration, login (password + passkey/WebAuthn), logout, session info, profile, password change.
+  - name: Measurements
+    description: CRUD for measurements (weight, BP, pulse, body fat, glucose, sleep, steps).
+  - name: Medications
+    description: Medication management, schedules, intake events, compliance, reminder phase config.
+  - name: Mood
+    description: Mood entries (manual + moodLog imports) and mood analytics.
+  - name: Dashboard
+    description: User-customizable dashboard widget layout.
+  - name: Insights
+    description: AI-generated insights, classifications (BMI, BP, mood, etc.), per-metric status, target ranges.
+  - name: Achievements
+    description: Gamification achievements (streaks, milestones).
+  - name: DoctorReport
+    description: Aggregated health data for client-side PDF export.
+  - name: Integrations
+    description: Withings, moodLog, Codex (ChatGPT) OAuth integrations.
+  - name: User
+    description: User-level configuration (AI provider, threshold overrides).
+  - name: Tokens
+    description: User-issued API tokens for external ingest.
+  - name: Notifications
+    description: Notification channels and preferences (Telegram, ntfy, Web Push).
+  - name: Onboarding
+    description: First-run profile setup.
+  - name: Health
+    description: Service health probe.
+  - name: Settings
+    description: Per-user settings (account deletion, data wipe, integrations, notifications).
+  - name: Analytics
+    description: Aggregated analytics summaries.
+  - name: Export
+    description: User data export (CSV/JSON) and re-import.
+  - name: AuditLog
+    description: User-facing audit log of own activity.
+  - name: Feedback
+    description: User feedback submission and history.
+  - name: BugReport
+    description: User bug reports (creates a GitHub issue when configured).
+  - name: Monitoring
+    description: Public monitoring/error reporting endpoints (CSP, Glitchtip, Umami proxy).
+  - name: Webhooks
+    description: Inbound webhooks (Withings, moodLog, Telegram).
+  - name: Ingest
+    description: External ingest endpoints authenticated via Bearer token.
+  - name: Admin
+    description: Internal admin-only endpoints. Not consumed by the iOS client.
+
+security:
+  - bearerAuth: []
+  - sessionCookie: []
+
+paths:
+  # ─── Auth ────────────────────────────────────────────────────────
+  /api/auth/register:
+    post:
+      tags: [Auth]
+      summary: Register a new user (password)
+      operationId: registerUser
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/RegisterInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterResponseEnvelope'
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/login:
+    post:
+      tags: [Auth]
+      summary: Login with email/username + password
+      operationId: loginUser
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/LoginInput' }
+      responses:
+        '200':
+          description: Authenticated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/LoginResponseEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/logout:
+    post:
+      tags: [Auth]
+      summary: Destroy current session
+      operationId: logoutUser
+      responses:
+        '200':
+          description: Logged out
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          loggedOut: { type: boolean }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/me:
+    get:
+      tags: [Auth]
+      summary: Get current authenticated user
+      operationId: getCurrentUser
+      responses:
+        '200':
+          description: Current user
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/CurrentUser' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/profile:
+    put:
+      tags: [Auth]
+      summary: Update profile (email, height, DOB, gender)
+      operationId: updateProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ProfileInput' }
+      responses:
+        '200':
+          description: Updated profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/User' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/password:
+    post:
+      tags: [Auth]
+      summary: Change password (invalidates other sessions)
+      operationId: changePassword
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ChangePasswordInput' }
+      responses:
+        '200':
+          description: Password changed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          changed: { type: boolean }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/auth/registration-status:
+    get:
+      tags: [Auth]
+      summary: Whether public registration is enabled
+      operationId: getRegistrationStatus
+      security: []
+      responses:
+        '200':
+          description: Registration status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          registrationEnabled: { type: boolean }
+
+  # ─── Passkeys (WebAuthn) ───────────────────────────────────────
+  /api/auth/passkey/register-options:
+    post:
+      tags: [Auth]
+      summary: Begin passkey registration — get WebAuthn options
+      operationId: getPasskeyRegisterOptions
+      responses:
+        '200':
+          description: WebAuthn registration options
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/PasskeyRegisterOptions' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/auth/passkey/register-verify:
+    post:
+      tags: [Auth]
+      summary: Complete passkey registration — verify attestation
+      operationId: verifyPasskeyRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PasskeyVerifyRegistrationInput' }
+      responses:
+        '200':
+          description: Passkey registered
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          verified: { type: boolean }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/auth/passkey/login-options:
+    post:
+      tags: [Auth]
+      summary: Begin passkey login — get WebAuthn options
+      operationId: getPasskeyLoginOptions
+      security: []
+      responses:
+        '200':
+          description: WebAuthn authentication options
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/PasskeyLoginOptions' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/auth/passkey/login-verify:
+    post:
+      tags: [Auth]
+      summary: Complete passkey login — verify assertion
+      operationId: verifyPasskeyLogin
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/PasskeyVerifyLoginInput' }
+      responses:
+        '200':
+          description: Authenticated via passkey
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/LoginResponseEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/auth/passkeys:
+    get:
+      tags: [Auth]
+      summary: List the user's passkeys
+      operationId: listPasskeys
+      responses:
+        '200':
+          description: List of passkeys
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/PasskeySummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/auth/passkeys/{id}:
+    delete:
+      tags: [Auth]
+      summary: Delete a passkey
+      operationId: deletePasskey
+      parameters:
+        - $ref: '#/components/parameters/IdPathParam'
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          success: { type: boolean }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ─── Codex (ChatGPT) OAuth ────────────────────────────────────
+  /api/auth/codex/authorize:
+    get:
+      tags: [Integrations]
+      summary: Begin ChatGPT OAuth flow (redirects to ChatGPT)
+      operationId: codexAuthorize
+      responses:
+        '302':
+          description: Redirect to ChatGPT auth URL
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/auth/codex/callback:
+    get:
+      tags: [Integrations]
+      summary: ChatGPT OAuth callback — exchange code for tokens
+      operationId: codexCallback
+      parameters:
+        - in: query
+          name: code
+          schema: { type: string }
+        - in: query
+          name: state
+          schema: { type: string }
+        - in: query
+          name: error
+          schema: { type: string }
+      responses:
+        '302':
+          description: Redirect back to /settings with status
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/auth/codex/disconnect:
+    delete:
+      tags: [Integrations]
+      summary: Disconnect ChatGPT integration
+      operationId: codexDisconnect
+      responses:
+        '200':
+          description: Disconnected
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          disconnected: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  # ─── Measurements ────────────────────────────────────────────────
+  /api/measurements:
+    get:
+      tags: [Measurements]
+      summary: List measurements (paginated, filterable)
+      operationId: listMeasurements
+      parameters:
+        - in: query
+          name: type
+          schema: { $ref: '#/components/schemas/MeasurementType' }
+        - in: query
+          name: from
+          schema: { type: string, format: date-time }
+        - in: query
+          name: to
+          schema: { type: string, format: date-time }
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - in: query
+          name: sortBy
+          schema:
+            type: string
+            enum: [type, value, measuredAt, source]
+            default: measuredAt
+        - in: query
+          name: sortDir
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+      responses:
+        '200':
+          description: List of measurements
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          measurements:
+                            type: array
+                            items: { $ref: '#/components/schemas/Measurement' }
+                          meta: { $ref: '#/components/schemas/PageMeta' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '500': { $ref: '#/components/responses/ServerError' }
+    post:
+      tags: [Measurements]
+      summary: Create a measurement (single or batch)
+      operationId: createMeasurement
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/CreateMeasurementInput'
+                - type: array
+                  items: { $ref: '#/components/schemas/CreateMeasurementInput' }
+                  minItems: 1
+                  maxItems: 5
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        oneOf:
+                          - $ref: '#/components/schemas/Measurement'
+                          - type: array
+                            items: { $ref: '#/components/schemas/Measurement' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '500': { $ref: '#/components/responses/ServerError' }
+
+  /api/measurements/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Measurements]
+      summary: Get a single measurement
+      operationId: getMeasurement
+      responses:
+        '200':
+          description: Measurement
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/Measurement' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [Measurements]
+      summary: Update a measurement
+      operationId: updateMeasurement
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateMeasurementInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/Measurement' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Measurements]
+      summary: Delete a measurement
+      operationId: deleteMeasurement
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ─── Medications ─────────────────────────────────────────────────
+  /api/medications:
+    get:
+      tags: [Medications]
+      summary: List medications (with today's intake summary)
+      operationId: listMedications
+      responses:
+        '200':
+          description: List
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/MedicationWithSchedules' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    post:
+      tags: [Medications]
+      summary: Create a medication with schedules
+      operationId: createMedication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateMedicationInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationWithSchedules' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/medications/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Medications]
+      summary: Get a single medication
+      operationId: getMedication
+      responses:
+        '200':
+          description: Medication
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationWithSchedules' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [Medications]
+      summary: Update a medication
+      operationId: updateMedication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateMedicationInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationWithSchedules' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Medications]
+      summary: Delete a medication (revokes its API tokens)
+      operationId: deleteMedication
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/medications/{id}/intake:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Medications]
+      summary: List intake events for a medication
+      operationId: listMedicationIntakes
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - in: query
+          name: sortBy
+          schema:
+            type: string
+            enum: [scheduledFor, takenAt, source, createdAt]
+            default: scheduledFor
+        - in: query
+          name: sortDir
+          schema: { type: string, enum: [asc, desc], default: desc }
+      responses:
+        '200':
+          description: Events
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          events:
+                            type: array
+                            items: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+                          meta: { $ref: '#/components/schemas/PageMeta' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    post:
+      tags: [Medications]
+      summary: Log a medication intake or skip
+      operationId: createMedicationIntake
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateIntakeInput' }
+      responses:
+        '200':
+          description: Idempotent return of existing event
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/medications/{id}/intake/{eventId}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+      - in: path
+        name: eventId
+        required: true
+        schema: { type: string }
+    put:
+      tags: [Medications]
+      summary: Update an intake event
+      operationId: updateMedicationIntake
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateIntakeInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Medications]
+      summary: Delete an intake event
+      operationId: deleteMedicationIntake
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/medications/{id}/intake/import:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Medications]
+      summary: Bulk-import historical intakes for one medication
+      operationId: importMedicationIntakes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: array
+                  items: { $ref: '#/components/schemas/IntakeImportEntry' }
+                  minItems: 1
+                  maxItems: 1000
+                - type: object
+                  description: Object whose first array-valued property is treated as the entries.
+                  additionalProperties: true
+      responses:
+        '201':
+          description: Import result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/IntakeImportResult' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/medications/{id}/intake/purge:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    delete:
+      tags: [Medications]
+      summary: Delete ALL intake events for a medication
+      operationId: purgeMedicationIntakes
+      responses:
+        '200':
+          description: Purged
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          purged: { type: boolean }
+                          count: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/medications/{id}/compliance:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Medications]
+      summary: Compliance summary for a medication (7d, 30d, 90 daily)
+      operationId: getMedicationCompliance
+      responses:
+        '200':
+          description: Compliance
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationComplianceResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/medications/{id}/phase-config:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Medications]
+      summary: Get reminder-phase config (or defaults)
+      operationId: getPhaseConfig
+      responses:
+        '200':
+          description: Phase config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ReminderPhaseConfig' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [Medications]
+      summary: Update reminder-phase config
+      operationId: updatePhaseConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ReminderPhaseConfig' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ReminderPhaseConfig' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Medications]
+      summary: Reset reminder-phase config to defaults
+      operationId: resetPhaseConfig
+      responses:
+        '200':
+          description: Reset
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          reset: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/medications/{id}/api-endpoint:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Medications]
+      summary: Whether an external API token is enabled for this medication
+      operationId: getMedicationApiEndpoint
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          enabled: { type: boolean }
+                          activeTokenCount: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [Medications]
+      summary: Enable / disable a medication-scoped API token
+      operationId: setMedicationApiEndpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled: { type: boolean }
+              required: [enabled]
+      responses:
+        '200':
+          description: Existing token reused or revocation result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationApiEndpointResponse' }
+        '201':
+          description: New medication-scoped token created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationApiEndpointResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/medications/intake-summary:
+    get:
+      tags: [Medications]
+      summary: Daily intake summary (for streak chart)
+      operationId: getIntakeSummary
+      parameters:
+        - in: query
+          name: from
+          schema: { type: string, format: date-time }
+        - in: query
+          name: to
+          schema: { type: string, format: date-time }
+      responses:
+        '200':
+          description: Summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/IntakeSummaryResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  # ─── Mood ─────────────────────────────────────────────────────
+  /api/mood-entries:
+    get:
+      tags: [Mood]
+      summary: List mood entries (paginated, filterable)
+      operationId: listMoodEntries
+      parameters:
+        - in: query
+          name: mood
+          schema: { $ref: '#/components/schemas/MoodLevel' }
+        - in: query
+          name: from
+          description: 'YYYY-MM-DD lower bound (inclusive).'
+          schema: { type: string }
+        - in: query
+          name: to
+          description: 'YYYY-MM-DD upper bound (inclusive).'
+          schema: { type: string }
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - in: query
+          name: sortBy
+          schema: { type: string, default: moodLoggedAt }
+        - in: query
+          name: sortDir
+          schema: { type: string, enum: [asc, desc], default: desc }
+      responses:
+        '200':
+          description: Mood entries
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          entries:
+                            type: array
+                            items: { $ref: '#/components/schemas/MoodEntry' }
+                          meta: { $ref: '#/components/schemas/PageMeta' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    post:
+      tags: [Mood]
+      summary: Create a mood entry
+      operationId: createMoodEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateMoodEntryInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MoodEntry' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/mood-entries/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    get:
+      tags: [Mood]
+      summary: Get a mood entry
+      operationId: getMoodEntry
+      responses:
+        '200':
+          description: Mood entry
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MoodEntry' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [Mood]
+      summary: Update a mood entry
+      operationId: updateMoodEntry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateMoodEntryInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MoodEntry' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Mood]
+      summary: Delete a mood entry
+      operationId: deleteMoodEntry
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/mood/analytics:
+    get:
+      tags: [Mood]
+      summary: Mood analytics (daily averages + summary)
+      operationId: getMoodAnalytics
+      responses:
+        '200':
+          description: Analytics
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MoodAnalytics' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── Dashboard ────────────────────────────────────────────────
+  /api/dashboard/widgets:
+    get:
+      tags: [Dashboard]
+      summary: Get the resolved dashboard widget layout
+      operationId: getDashboardWidgets
+      responses:
+        '200':
+          description: Layout
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/DashboardLayout' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Dashboard]
+      summary: Replace the dashboard widget layout
+      operationId: updateDashboardWidgets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/DashboardLayout' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/DashboardLayout' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Dashboard]
+      summary: Reset dashboard layout to defaults
+      operationId: resetDashboardWidgets
+      responses:
+        '200':
+          description: Reset
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/DashboardLayout' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── Insights ────────────────────────────────────────────────
+  /api/insights/comprehensive:
+    get:
+      tags: [Insights]
+      summary: Comprehensive 90-day analytics bundle
+      operationId: getComprehensiveInsights
+      responses:
+        '200':
+          description: Insights bundle
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ComprehensiveInsights' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/generate:
+    post:
+      tags: [Insights]
+      summary: Generate AI-narrative insights (cached for 24h)
+      operationId: generateInsights
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                force: { type: boolean, description: 'Bypass 24h cache' }
+      responses:
+        '200':
+          description: Insights
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightGenerateResult' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '502':
+          description: Upstream AI provider failure
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+
+  /api/insights/settings:
+    get:
+      tags: [Insights]
+      summary: Get insights settings (privacy mode, provider status)
+      operationId: getInsightsSettings
+      responses:
+        '200':
+          description: Settings
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightsSettings' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Insights]
+      summary: Update insights settings (privacy mode)
+      operationId: updateInsightsSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                privacyMode: { type: string, enum: [aggregated, raw] }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          updated: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/insights/targets:
+    get:
+      tags: [Insights]
+      summary: Per-metric target ranges + classification
+      operationId: getInsightTargets
+      responses:
+        '200':
+          description: Targets
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightTargetsResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/blood-pressure-status:
+    get:
+      tags: [Insights]
+      summary: BP-specific narrative status
+      operationId: getBloodPressureStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: BP status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/bmi-status:
+    get:
+      tags: [Insights]
+      summary: BMI narrative status
+      operationId: getBmiStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: BMI status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/general-status:
+    get:
+      tags: [Insights]
+      summary: General health narrative status
+      operationId: getGeneralStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/medication-compliance-status:
+    get:
+      tags: [Insights]
+      summary: Medication compliance narrative status
+      operationId: getMedicationComplianceStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/mood-status:
+    get:
+      tags: [Insights]
+      summary: Mood narrative status
+      operationId: getMoodStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/pulse-status:
+    get:
+      tags: [Insights]
+      summary: Pulse narrative status
+      operationId: getPulseStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/weight-status:
+    get:
+      tags: [Insights]
+      summary: Weight narrative status
+      operationId: getWeightStatus
+      parameters:
+        - $ref: '#/components/parameters/LocaleParam'
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/InsightStatusBundle' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── Achievements ─────────────────────────────────────────────
+  /api/gamification/achievements:
+    get:
+      tags: [Achievements]
+      summary: Get achievements progress + unlocks
+      operationId: getAchievements
+      responses:
+        '200':
+          description: Achievements
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/AchievementsResult' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── DoctorReport ─────────────────────────────────────────────
+  /api/doctor-report:
+    post:
+      tags: [DoctorReport]
+      summary: Aggregated health data for doctor-report PDF
+      operationId: getDoctorReport
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                days:
+                  type: integer
+                  minimum: 1
+                  maximum: 365
+                  default: 90
+      responses:
+        '200':
+          description: Report data
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/DoctorReportResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  # ─── Onboarding ───────────────────────────────────────────────
+  /api/onboarding/complete:
+    post:
+      tags: [Onboarding]
+      summary: Mark onboarding complete and save initial profile
+      operationId: completeOnboarding
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/OnboardingInput' }
+      responses:
+        '200':
+          description: Completed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          completed: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  # ─── Health probe ─────────────────────────────────────────────
+  /api/health:
+    get:
+      tags: [Health]
+      summary: Service liveness probe
+      operationId: healthCheck
+      security: []
+      responses:
+        '200':
+          description: Healthy
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/HealthStatus' }
+        '503':
+          description: Degraded
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/HealthStatus' }
+
+  # ─── Tokens ──────────────────────────────────────────────────
+  /api/tokens:
+    get:
+      tags: [Tokens]
+      summary: List the user's API tokens (metadata only — secrets never returned)
+      operationId: listTokens
+      responses:
+        '200':
+          description: Tokens
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/ApiTokenSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    post:
+      tags: [Tokens]
+      summary: Create an API token (token returned ONCE)
+      operationId: createToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateTokenInput' }
+      responses:
+        '201':
+          description: Created (token visible once)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          token: { type: string, example: 'hlk_<hex>' }
+                          name: { type: string }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/tokens/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    delete:
+      tags: [Tokens]
+      summary: Revoke an API token
+      operationId: revokeToken
+      responses:
+        '200':
+          description: Revoked
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          revoked: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ─── Ingest (external) ────────────────────────────────────────
+  /api/ingest/medication:
+    post:
+      tags: [Ingest]
+      summary: External medication intake ingest (Bearer token, idempotent)
+      operationId: ingestMedicationIntake
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExternalIntakeInput' }
+      responses:
+        '200':
+          description: Existing event returned (idempotent replay)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MedicationIntakeEvent' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  # ─── Notifications ────────────────────────────────────────────
+  /api/notifications/preferences:
+    get:
+      tags: [Notifications]
+      summary: List notification channels + preferences
+      operationId: getNotificationPreferences
+      responses:
+        '200':
+          description: Preferences
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/NotificationPreferencesResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Notifications]
+      summary: Toggle a single channel/event preference
+      operationId: updateNotificationPreference
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateNotificationPreferenceInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/NotificationPreference' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/notifications/vapid:
+    get:
+      tags: [Notifications]
+      summary: Get VAPID public key (Web Push)
+      operationId: getVapidKey
+      security: []
+      responses:
+        '200':
+          description: VAPID key
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          publicKey: { type: string }
+        '503':
+          description: Not configured
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+
+  /api/notifications/web-push:
+    post:
+      tags: [Notifications]
+      summary: Subscribe a Web Push endpoint
+      operationId: subscribeWebPush
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/WebPushSubscribeInput' }
+      responses:
+        '200':
+          description: Subscribed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          subscribed: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Notifications]
+      summary: Unsubscribe a Web Push endpoint
+      operationId: unsubscribeWebPush
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                endpoint: { type: string, format: uri }
+              required: [endpoint]
+      responses:
+        '200':
+          description: Unsubscribed
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          unsubscribed: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  # ─── User configuration ───────────────────────────────────────
+  /api/user/ai-provider:
+    get:
+      tags: [User]
+      summary: Get user-level AI provider config
+      operationId: getUserAiProvider
+      responses:
+        '200':
+          description: Config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/UserAiProvider' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    patch:
+      tags: [User]
+      summary: Update user-level AI provider config
+      operationId: updateUserAiProvider
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateUserAiProviderInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          updated: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/user/thresholds:
+    get:
+      tags: [User]
+      summary: Get effective + override threshold ranges
+      operationId: getThresholds
+      responses:
+        '200':
+          description: Thresholds
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ThresholdsResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    put:
+      tags: [User]
+      summary: Set per-metric threshold overrides (partial)
+      operationId: updateThresholds
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ThresholdOverrides' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          overrides: { $ref: '#/components/schemas/ThresholdOverrides' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [User]
+      summary: Reset threshold overrides (all or one metric)
+      operationId: resetThresholds
+      parameters:
+        - in: query
+          name: metric
+          schema: { type: string }
+          description: 'If supplied, only this metric is reset; otherwise all overrides are cleared.'
+      responses:
+        '200':
+          description: Reset
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          overrides: { $ref: '#/components/schemas/ThresholdOverrides' }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── Analytics + AI test ──────────────────────────────────────
+  /api/analytics:
+    get:
+      tags: [Analytics]
+      summary: Per-type measurement summaries + BMI + BP-in-target
+      operationId: getAnalytics
+      responses:
+        '200':
+          description: Analytics
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/AnalyticsResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/ai/test:
+    post:
+      tags: [User]
+      summary: Test the configured AI provider
+      operationId: testAiProvider
+      responses:
+        '200':
+          description: AI test result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/AiTestResult' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '502':
+          description: Upstream AI provider failure
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+
+  # ─── Export / Import ──────────────────────────────────────────
+  /api/export:
+    get:
+      tags: [Export]
+      summary: Export user data (CSV or JSON)
+      operationId: exportData
+      parameters:
+        - in: query
+          name: format
+          schema: { type: string, enum: [csv, json], default: json }
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [measurements, medications, intake, mood, all]
+            default: all
+      responses:
+        '200':
+          description: Export payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+            text/csv:
+              schema: { type: string }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/import:
+    post:
+      tags: [Export]
+      summary: Import previously exported data (JSON)
+      operationId: importData
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ImportInput' }
+      responses:
+        '200':
+          description: Import stats
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ImportResult' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  # ─── Audit log + Feedback + Bug report ────────────────────────
+  /api/audit-log:
+    get:
+      tags: [AuditLog]
+      summary: Personal audit log entries
+      operationId: getAuditLog
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Entries
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/AuditLogResponse' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/feedback:
+    get:
+      tags: [Feedback]
+      summary: List the user's submitted feedback
+      operationId: listFeedback
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200':
+          description: Feedback
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          items:
+                            type: array
+                            items: { $ref: '#/components/schemas/FeedbackSummary' }
+                          meta: { $ref: '#/components/schemas/PageMeta' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    post:
+      tags: [Feedback]
+      summary: Submit feedback (with optional screenshot)
+      operationId: submitFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateFeedbackInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/FeedbackSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/bugreport:
+    post:
+      tags: [BugReport]
+      summary: File a bug report (creates a GitHub issue when configured)
+      operationId: submitBugReport
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/BugReportInput' }
+      responses:
+        '200':
+          description: Issue created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          issueNumber: { type: integer }
+                          issueUrl: { type: string, format: uri }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+        '500': { $ref: '#/components/responses/ServerError' }
+        '503':
+          description: Bug report not configured
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+
+  /api/bugreport/status:
+    get:
+      tags: [BugReport]
+      summary: Whether bug-report submission is configured
+      operationId: getBugReportStatus
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          configured: { type: boolean }
+                          isAdmin: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  # ─── Settings (per-user) ──────────────────────────────────────
+  /api/settings/account:
+    delete:
+      tags: [Settings]
+      summary: Delete the user's account (and all data)
+      operationId: deleteAccount
+      responses:
+        '200':
+          description: Account deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/data:
+    delete:
+      tags: [Settings]
+      summary: Wipe the user's data (keep account)
+      operationId: wipeData
+      responses:
+        '200':
+          description: Data wiped
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/global-services:
+    get:
+      tags: [Settings]
+      summary: Global service availability flags (telegram, ntfy, web-push, …)
+      operationId: getGlobalServices
+      responses:
+        '200':
+          description: Flags
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/GlobalServicesFlags' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/moodlog:
+    put:
+      tags: [Settings]
+      summary: Configure moodLog integration
+      operationId: updateMoodLogSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/MoodLogSettingsInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UpdatedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Settings]
+      summary: Disconnect moodLog integration
+      operationId: deleteMoodLogSettings
+      responses:
+        '200':
+          description: Removed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/ntfy:
+    get:
+      tags: [Settings]
+      summary: Get ntfy channel settings
+      operationId: getNtfySettings
+      responses:
+        '200':
+          description: Config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/NtfySettings' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Settings]
+      summary: Update ntfy channel settings
+      operationId: updateNtfySettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NtfySettingsInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UpdatedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/settings/ntfy/test:
+    post:
+      tags: [Settings]
+      summary: Send a test ntfy notification
+      operationId: testNtfy
+      responses:
+        '200':
+          description: Test result
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/reminder-thresholds:
+    get:
+      tags: [Settings]
+      summary: Get reminder lateness thresholds (admin-defined defaults)
+      operationId: getReminderThresholds
+      responses:
+        '200':
+          description: Thresholds
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/ReminderThresholds' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/settings/telegram:
+    get:
+      tags: [Settings]
+      summary: Get Telegram channel settings
+      operationId: getTelegramSettings
+      responses:
+        '200':
+          description: Config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/TelegramSettings' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Settings]
+      summary: Update Telegram channel settings
+      operationId: updateTelegramSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TelegramSettingsInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UpdatedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/settings/telegram/test:
+    post:
+      tags: [Settings]
+      summary: Send a test Telegram message
+      operationId: testTelegram
+      responses:
+        '200':
+          description: Test result
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  # ─── Withings integration ────────────────────────────────────
+  /api/withings/connect:
+    get:
+      tags: [Integrations]
+      summary: Begin Withings OAuth (302 redirect)
+      operationId: withingsConnect
+      responses:
+        '302':
+          description: Redirect to Withings
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/withings/callback:
+    get:
+      tags: [Integrations]
+      summary: Withings OAuth callback (302 to /settings)
+      operationId: withingsCallback
+      parameters:
+        - in: query
+          name: code
+          schema: { type: string }
+        - in: query
+          name: state
+          schema: { type: string }
+      responses:
+        '302':
+          description: Redirect back to /settings with status
+
+  /api/withings/disconnect:
+    post:
+      tags: [Integrations]
+      summary: Disconnect Withings
+      operationId: withingsDisconnect
+      responses:
+        '200':
+          description: Disconnected
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          disconnected: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/withings/credentials:
+    get:
+      tags: [Integrations]
+      summary: Whether Withings client credentials are stored
+      operationId: getWithingsCredentialsStatus
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          hasCredentials: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    put:
+      tags: [Integrations]
+      summary: Save Withings client ID + secret (encrypted)
+      operationId: saveWithingsCredentials
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/WithingsCredentialsInput' }
+      responses:
+        '200':
+          description: Saved
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/UpdatedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    delete:
+      tags: [Integrations]
+      summary: Delete Withings credentials (and disconnect)
+      operationId: deleteWithingsCredentials
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeletedEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/withings/status:
+    get:
+      tags: [Integrations]
+      summary: Withings connection status
+      operationId: withingsStatus
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/WithingsStatus' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/withings/sync:
+    post:
+      tags: [Integrations]
+      summary: Trigger a Withings sync (incremental or full)
+      operationId: withingsSync
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fullSync: { type: boolean, default: false }
+      responses:
+        '200':
+          description: Sync result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          imported: { type: integer }
+                          fullSync: { type: boolean }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/withings/webhook:
+    post:
+      tags: [Webhooks]
+      summary: Withings webhook (notification of new measurements)
+      operationId: withingsWebhook
+      security: []
+      parameters:
+        - in: query
+          name: secret
+          schema: { type: string }
+          description: 'Shared secret for webhook authentication.'
+      responses:
+        '200':
+          description: Acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+        '401':
+          description: Unauthorized
+        '429':
+          description: Rate limited
+    get:
+      tags: [Webhooks]
+      summary: Withings webhook URL verification
+      operationId: withingsWebhookVerifyGet
+      security: []
+      parameters:
+        - in: query
+          name: secret
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+        '401':
+          description: Unauthorized
+    head:
+      tags: [Webhooks]
+      summary: Withings webhook URL verification (HEAD)
+      operationId: withingsWebhookVerifyHead
+      security: []
+      parameters:
+        - in: query
+          name: secret
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Unauthorized
+
+  # ─── moodLog integration ─────────────────────────────────────
+  /api/integrations/moodlog/status:
+    get:
+      tags: [Integrations]
+      summary: moodLog connection status
+      operationId: moodLogStatus
+      responses:
+        '200':
+          description: Status
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MoodLogStatus' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/integrations/moodlog/sync:
+    post:
+      tags: [Integrations]
+      summary: Trigger a moodLog sync
+      operationId: moodLogSync
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fullSync: { type: boolean, default: false }
+      responses:
+        '200':
+          description: Sync result
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          imported: { type: integer }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/integrations/moodlog/webhook:
+    post:
+      tags: [Webhooks]
+      summary: Inbound webhook from moodLog
+      operationId: moodLogWebhook
+      security: []
+      parameters:
+        - in: header
+          name: X-Webhook-Secret
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Acknowledged
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '429': { $ref: '#/components/responses/RateLimited' }
+
+  /api/telegram/webhook:
+    post:
+      tags: [Webhooks]
+      summary: Telegram inbound webhook
+      operationId: telegramWebhook
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Acknowledged
+    get:
+      tags: [Webhooks]
+      summary: Telegram webhook health probe
+      operationId: telegramWebhookGet
+      security: []
+      responses:
+        '200':
+          description: OK
+
+  # ─── Public monitoring / proxies ─────────────────────────────
+  /api/monitoring/csp-report:
+    post:
+      tags: [Monitoring]
+      summary: Browser CSP violation report sink
+      operationId: cspReport
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/csp-report:
+            schema:
+              type: object
+              additionalProperties: true
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '204':
+          description: Accepted (no body)
+
+  /api/monitoring/glitchtip:
+    post:
+      tags: [Monitoring]
+      summary: Forward errors to Glitchtip
+      operationId: glitchtipReport
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '204':
+          description: Accepted
+
+  /api/monitoring/settings:
+    get:
+      tags: [Monitoring]
+      summary: Public monitoring settings (umami / glitchtip flags)
+      operationId: getMonitoringSettings
+      security: []
+      responses:
+        '200':
+          description: Public settings
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/PublicMonitoringSettings' }
+
+  /api/monitoring/umami-script:
+    get:
+      tags: [Monitoring]
+      summary: Server-side proxy for the Umami tracker script
+      operationId: getUmamiScript
+      security: []
+      responses:
+        '200':
+          description: Tracker script
+          content:
+            application/javascript:
+              schema: { type: string }
+
+  /api/send:
+    post:
+      tags: [Monitoring]
+      summary: Server-side proxy for Umami /api/send
+      operationId: umamiProxySend
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        '200':
+          description: Forwarded
+        '204':
+          description: No-op when umami is disabled
+        '413':
+          description: Payload too large
+
+  # ─── Admin (internal) ────────────────────────────────────────
+  /api/admin/ai-settings:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: get admin-managed AI fallback settings'
+      operationId: adminGetAiSettings
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    put:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: update admin-managed AI fallback settings'
+      operationId: adminUpdateAiSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, additionalProperties: true }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/admin/audit-log:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: cross-user audit log'
+      operationId: adminGetAuditLog
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/data:
+    delete:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: wipe per-user or all data'
+      operationId: adminWipeData
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/feedback:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: list all feedback'
+      operationId: adminListFeedback
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/feedback/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    patch:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: update feedback status / admin note'
+      operationId: adminUpdateFeedback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, additionalProperties: true }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: delete feedback'
+      operationId: adminDeleteFeedback
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/admin/feedback/{id}/github:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: escalate feedback to a GitHub issue'
+      operationId: adminEscalateFeedback
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  /api/admin/monitoring/glitchtip-test:
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: send Glitchtip test event'
+      operationId: adminGlitchtipTest
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/monitoring/umami-test:
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: send Umami test ping'
+      operationId: adminUmamiTest
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/notifications/reminder-check:
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: trigger medication reminder evaluation'
+      operationId: adminTriggerReminderCheck
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/notifications/test:
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: send a test notification'
+      operationId: adminTestNotification
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/settings:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: get app-wide settings'
+      operationId: adminGetSettings
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+    put:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: update app-wide settings'
+      operationId: adminUpdateSettings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object, additionalProperties: true }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/admin/status:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: deep system status'
+      operationId: adminStatus
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/tokens:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: list all API tokens (cross-user)'
+      operationId: adminListTokens
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/users:
+    get:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: list all users'
+      operationId: adminListUsers
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+
+  /api/admin/users/{id}:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    put:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: 'Internal: update a user (username/email/role)'
+      operationId: adminUpdateUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AdminUpdateUserInput' }
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/admin/users/{id}/reset-password:
+    parameters:
+      - $ref: '#/components/parameters/IdPathParam'
+    post:
+      tags: [Admin]
+      security:
+        - sessionCookie: []
+      summary: "Internal: reset a user's password"
+      operationId: adminResetUserPassword
+      responses:
+        '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/ApiEnvelope' } } } }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+
+  # ─── iOS adapter endpoints (v1.3) ────────────────────────────────────
+
+  /api/dashboard/summary:
+    get:
+      tags: [Dashboard]
+      summary: 'iOS: aggregated dashboard summary'
+      description: |
+        Single-call aggregate for the iOS DashboardSummary view. Combines
+        greeting, current/longest activity-day streak, today's medication
+        compliance, optional highlight insight, and per-metric latest +
+        7-day sparkline + trend.
+      operationId: getDashboardSummary
+      responses:
+        '200':
+          description: Dashboard summary
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/DashboardSummary' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/measurements/series:
+    get:
+      tags: [Measurements]
+      summary: 'iOS: time-series + summary stats for a metric kind'
+      operationId: getMeasurementSeries
+      parameters:
+        - in: query
+          name: kind
+          required: true
+          schema: { $ref: '#/components/schemas/MetricKind' }
+        - in: query
+          name: days
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 365
+            default: 30
+      responses:
+        '200':
+          description: Series payload
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/MeasurementSeries' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/integrations/healthkit:
+    get:
+      tags: [Integrations]
+      summary: 'iOS: HealthKit per-metric direction config'
+      operationId: getHealthKitConfig
+      responses:
+        '200':
+          description: HealthKit config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/HealthKitConfig' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    patch:
+      tags: [Integrations]
+      summary: 'iOS: update HealthKit per-metric direction config'
+      operationId: updateHealthKitConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/HealthKitConfigPatch' }
+      responses:
+        '200':
+          description: Updated config
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/HealthKitConfig' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/user/profile:
+    get:
+      tags: [Auth]
+      summary: 'iOS: flattened user profile'
+      operationId: getUserProfile
+      responses:
+        '200':
+          description: User profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/IosUserProfile' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+    patch:
+      tags: [Auth]
+      summary: 'iOS: update profile fields'
+      operationId: updateUserProfile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/IosUserProfilePatch' }
+      responses:
+        '200':
+          description: Updated profile
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/IosUserProfile' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '409': { $ref: '#/components/responses/Conflict' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/devices:
+    post:
+      tags: [Notifications]
+      summary: 'iOS: register an APNs device token'
+      operationId: registerDevice
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/DeviceRegisterInput' }
+      responses:
+        '201':
+          description: Device registered (or token transferred)
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          id: { type: string }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/medications/intake:
+    get:
+      tags: [Medications]
+      summary: 'iOS: today list or compliance buckets'
+      operationId: listIntakeAggregator
+      parameters:
+        - in: query
+          name: scope
+          required: true
+          schema: { type: string, enum: [today, compliance] }
+        - in: query
+          name: days
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 365
+            default: 30
+      responses:
+        '200':
+          description: Aggregator payload
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+    post:
+      tags: [Medications]
+      summary: 'iOS: update an intake event by id (taken/skipped/snoozed)'
+      operationId: updateIntakeAggregator
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/IntakeUpdateInput' }
+      responses:
+        '200':
+          description: Updated intake event
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiEnvelope' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/Unprocessable' }
+
+  /api/insights/cards:
+    get:
+      tags: [Insights]
+      summary: 'iOS: rule-based insight cards'
+      operationId: getInsightCards
+      responses:
+        '200':
+          description: Insight cards
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/InsightCard' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+  /api/insights/correlations:
+    get:
+      tags: [Insights]
+      summary: 'iOS: cross-metric correlations (placeholder)'
+      operationId: getInsightCorrelations
+      description: |
+        Returns an empty array until the correlations engine is wired up
+        (Phase 7). Audited via `insights.correlations.empty`.
+      responses:
+        '200':
+          description: Correlations
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/ApiEnvelope'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: '#/components/schemas/InsightCorrelation' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: 'hlk_<hex>'
+      description: |
+        Long-lived API token issued via `POST /api/tokens`. Accepted on all
+        user endpoints (interchangeable with the session cookie) and required
+        on external ingest endpoints (e.g. `/api/ingest/medication`). Tokens
+        are prefixed `hlk_` and stored as SHA-256 hashes server-side. Bearer
+        tokens never grant admin access — admin routes require the session
+        cookie. Permission scopes are enforced from the token's `permissions`
+        array.
+    sessionCookie:
+      type: apiKey
+      in: cookie
+      name: healthlog_session
+      description: |
+        HttpOnly session cookie set by `/api/auth/login` and the passkey
+        login flow. Authenticates the web app and (optionally) the iOS
+        client when used in a web view.
+
+  parameters:
+    IdPathParam:
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+        description: 'CUID identifier.'
+    LimitParam:
+      in: query
+      name: limit
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 500
+        default: 100
+    OffsetParam:
+      in: query
+      name: offset
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    LocaleParam:
+      in: query
+      name: locale
+      schema:
+        type: string
+        enum: [de, en]
+      description: 'Override the resolved locale for narrative text.'
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    Unauthorized:
+      description: Authentication required
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    Forbidden:
+      description: Forbidden
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    NotFound:
+      description: Not found
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    Conflict:
+      description: Conflict (e.g. duplicate)
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    Unprocessable:
+      description: Validation failure
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    RateLimited:
+      description: Rate limit exceeded
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+    ServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema: { $ref: '#/components/schemas/ApiError' }
+
+  schemas:
+    # ─── Envelope / errors ─────────────────────────────────────
+    ApiEnvelope:
+      type: object
+      description: Standard envelope. On success `error` is `null`; on failure `data` is `null` and `error` is a string.
+      properties:
+        data:
+          description: Response payload (typed per-endpoint).
+        error:
+          type: [string, 'null']
+      required: [data, error]
+
+    ApiError:
+      type: object
+      properties:
+        data:
+          type: 'null'
+        error:
+          type: string
+      required: [data, error]
+
+    DeletedEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelope'
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                deleted: { type: boolean }
+
+    UpdatedEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelope'
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                updated: { type: boolean }
+
+    PageMeta:
+      type: object
+      properties:
+        total: { type: integer }
+        limit: { type: integer }
+        offset: { type: integer }
+      required: [total, limit, offset]
+
+    # ─── Enums ─────────────────────────────────────────────────
+    MeasurementType:
+      type: string
+      enum:
+        - WEIGHT
+        - BLOOD_PRESSURE_SYS
+        - BLOOD_PRESSURE_DIA
+        - PULSE
+        - BODY_FAT
+        - SLEEP_DURATION
+        - ACTIVITY_STEPS
+        - BLOOD_GLUCOSE
+
+    MeasurementSource:
+      type: string
+      enum: [MANUAL, WITHINGS, IMPORT]
+
+    GlucoseContext:
+      type: string
+      enum: [FASTING, POSTPRANDIAL, RANDOM, BEDTIME]
+
+    IntakeSource:
+      type: string
+      enum: [WEB, API, REMINDER, IMPORT]
+
+    ReminderPhase:
+      type: string
+      enum: [GREEN, YELLOW, ORANGE, RED]
+
+    PhaseMode:
+      type: string
+      enum: [MINUTES, PERCENT]
+
+    UserRole:
+      type: string
+      enum: [ADMIN, USER]
+
+    Gender:
+      type: string
+      enum: [MALE, FEMALE]
+
+    MoodLevel:
+      type: string
+      enum: [SUPER_GUT, GUT, OKAY, SCHLECHT, LAUSIG]
+
+    MedicationCategory:
+      type: string
+      enum:
+        - BLOOD_PRESSURE
+        - VITAMIN
+        - SUPPLEMENT
+        - PAIN_RELIEF
+        - ALLERGY
+        - DIGESTIVE
+        - THYROID
+        - HORMONE
+        - SKIN
+        - SLEEP_AID
+        - OTHER
+
+    NotificationChannelType:
+      type: string
+      enum: [TELEGRAM, NTFY, WEB_PUSH]
+
+    AiProviderType:
+      type: string
+      enum: [OPENAI, ANTHROPIC, LOCAL, CHATGPT_OAUTH]
+
+    InsightSeverity:
+      type: string
+      enum: [normal, mild, moderate, severe, info]
+
+    Trend:
+      type: [string, 'null']
+      enum: [up, down, stable, null]
+
+    # ─── Auth DTOs ─────────────────────────────────────────────
+    RegisterInput:
+      type: object
+      properties:
+        email: { type: string, format: email }
+        username:
+          type: string
+          minLength: 3
+          maxLength: 30
+          pattern: '^[a-zA-Z0-9_-]+$'
+        password:
+          type: string
+          minLength: 12
+      required: [email, username, password]
+
+    LoginInput:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Email or username.
+        password: { type: string }
+      required: [email, password]
+
+    LoginResponseEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelope'
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    username: { type: string }
+                  required: [id, username]
+                token:
+                  type: string
+                  description: |
+                    Long-lived `hlk_*` Bearer token. Only returned when the
+                    request carries `X-Client-Type: native` or a User-Agent
+                    starting with `HealthLog-iOS`. Use it for subsequent
+                    requests as `Authorization: Bearer <token>`.
+                tokenExpiresAt:
+                  type: string
+                  format: date-time
+                  description: ISO timestamp at which the auto-issued token expires.
+
+    RegisterResponseEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/ApiEnvelope'
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    username: { type: string }
+                    email: { type: [string, 'null'] }
+
+    ProfileInput:
+      type: object
+      properties:
+        email: { type: [string, 'null'], format: email }
+        heightCm:
+          type: [number, 'null']
+          minimum: 50
+          maximum: 300
+        dateOfBirth:
+          type: [string, 'null']
+          format: date
+        gender:
+          oneOf:
+            - $ref: '#/components/schemas/Gender'
+            - type: 'null'
+
+    ChangePasswordInput:
+      type: object
+      properties:
+        currentPassword: { type: string }
+        newPassword: { type: string, minLength: 12 }
+        confirmPassword: { type: string }
+      required: [currentPassword, newPassword, confirmPassword]
+
+    User:
+      type: object
+      description: Public-facing user shape.
+      properties:
+        id: { type: string }
+        username: { type: string }
+        email: { type: [string, 'null'], format: email }
+        role: { $ref: '#/components/schemas/UserRole' }
+        heightCm: { type: [number, 'null'] }
+        dateOfBirth: { type: [string, 'null'], format: date-time }
+        gender:
+          oneOf:
+            - $ref: '#/components/schemas/Gender'
+            - type: 'null'
+        timezone: { type: string }
+      required: [id, username, role, timezone]
+
+    CurrentUser:
+      allOf:
+        - $ref: '#/components/schemas/User'
+        - type: object
+          properties:
+            onboardingCompletedAt:
+              type: [string, 'null']
+              format: date-time
+            gravatarUrl:
+              type: [string, 'null']
+            glucoseUnit:
+              type: [string, 'null']
+              enum: ['mg/dL', 'mmol/L', null]
+
+    # ─── Passkey DTOs ──────────────────────────────────────────
+    PasskeyRegisterOptions:
+      type: object
+      description: SimpleWebAuthn `PublicKeyCredentialCreationOptionsJSON` plus a server-issued challenge id.
+      properties:
+        options:
+          type: object
+          additionalProperties: true
+          description: WebAuthn registration options.
+        challengeId: { type: string }
+      required: [options, challengeId]
+
+    PasskeyLoginOptions:
+      type: object
+      properties:
+        options:
+          type: object
+          additionalProperties: true
+          description: WebAuthn authentication options.
+        challengeId: { type: string }
+      required: [options, challengeId]
+
+    PasskeyVerifyRegistrationInput:
+      type: object
+      properties:
+        challengeId: { type: string }
+        credential:
+          type: object
+          additionalProperties: true
+          description: '`RegistrationResponseJSON` from `@simplewebauthn/browser`.'
+      required: [challengeId, credential]
+
+    PasskeyVerifyLoginInput:
+      type: object
+      properties:
+        challengeId: { type: string }
+        credential:
+          type: object
+          additionalProperties: true
+          description: '`AuthenticationResponseJSON` from `@simplewebauthn/browser`.'
+      required: [challengeId, credential]
+
+    PasskeySummary:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        credentialDeviceType: { type: string }
+        credentialBackedUp: { type: boolean }
+        createdAt: { type: string, format: date-time }
+      required: [id, name, credentialDeviceType, credentialBackedUp, createdAt]
+
+    # ─── Measurement DTOs ──────────────────────────────────────
+    Measurement:
+      type: object
+      properties:
+        id: { type: string }
+        userId: { type: string }
+        type: { $ref: '#/components/schemas/MeasurementType' }
+        value: { type: number }
+        unit: { type: string }
+        source: { $ref: '#/components/schemas/MeasurementSource' }
+        measuredAt: { type: string, format: date-time }
+        notes: { type: [string, 'null'], maxLength: 25 }
+        externalId: { type: [string, 'null'] }
+        glucoseContext:
+          oneOf:
+            - $ref: '#/components/schemas/GlucoseContext'
+            - type: 'null'
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+      required: [id, userId, type, value, unit, source, measuredAt, createdAt, updatedAt]
+
+    CreateMeasurementInput:
+      type: object
+      properties:
+        type: { $ref: '#/components/schemas/MeasurementType' }
+        value: { type: number }
+        measuredAt: { type: string, format: date-time }
+        notes: { type: string, maxLength: 25 }
+        source:
+          allOf: [{ $ref: '#/components/schemas/MeasurementSource' }]
+          default: MANUAL
+        glucoseContext:
+          $ref: '#/components/schemas/GlucoseContext'
+      required: [type, value, measuredAt]
+
+    UpdateMeasurementInput:
+      type: object
+      properties:
+        value: { type: number, minimum: 0, maximum: 500000 }
+        measuredAt: { type: string, format: date-time }
+        notes: { type: [string, 'null'], maxLength: 25 }
+
+    # ─── Medication DTOs ───────────────────────────────────────
+    MedicationSchedule:
+      type: object
+      properties:
+        id: { type: string }
+        medicationId: { type: string }
+        windowStart:
+          type: string
+          pattern: '^([01]\d|2[0-3]):([0-5]\d)$'
+          description: HH:mm
+        windowEnd:
+          type: string
+          pattern: '^([01]\d|2[0-3]):([0-5]\d)$'
+        label: { type: [string, 'null'] }
+        dose: { type: [string, 'null'], description: 'Per-schedule dose override' }
+        daysOfWeek:
+          type: [string, 'null']
+          description: 'Serialized recurrence (CSV of 0..6, optional intervalWeeks suffix).'
+      required: [id, medicationId, windowStart, windowEnd]
+
+    Medication:
+      type: object
+      properties:
+        id: { type: string }
+        userId: { type: string }
+        name: { type: string }
+        dose: { type: string }
+        active: { type: boolean }
+        notificationsEnabled: { type: boolean }
+        pausedAt: { type: [string, 'null'], format: date-time }
+        snoozedUntil: { type: [string, 'null'], format: date-time }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+      required: [id, userId, name, dose, active, notificationsEnabled, createdAt, updatedAt]
+
+    MedicationWithSchedules:
+      allOf:
+        - $ref: '#/components/schemas/Medication'
+        - type: object
+          properties:
+            schedules:
+              type: array
+              items: { $ref: '#/components/schemas/MedicationSchedule' }
+            category: { $ref: '#/components/schemas/MedicationCategory' }
+            lastTakenAt:
+              type: [string, 'null']
+              format: date-time
+            todayEventCount:
+              type: integer
+
+    MedicationScheduleInput:
+      type: object
+      properties:
+        windowStart: { type: string, pattern: '^([01]\d|2[0-3]):([0-5]\d)$' }
+        windowEnd: { type: string, pattern: '^([01]\d|2[0-3]):([0-5]\d)$' }
+        label: { type: string, maxLength: 50 }
+        dose: { type: string, maxLength: 50 }
+        daysOfWeek:
+          type: array
+          items: { type: integer, minimum: 0, maximum: 6 }
+        intervalWeeks:
+          type: integer
+          minimum: 1
+          maximum: 4
+      required: [windowStart, windowEnd]
+
+    CreateMedicationInput:
+      type: object
+      properties:
+        name: { type: string, minLength: 1, maxLength: 100 }
+        dose: { type: string, minLength: 1, maxLength: 50 }
+        category: { $ref: '#/components/schemas/MedicationCategory' }
+        schedules:
+          type: array
+          minItems: 1
+          items: { $ref: '#/components/schemas/MedicationScheduleInput' }
+      required: [name, dose, schedules]
+
+    UpdateMedicationInput:
+      type: object
+      properties:
+        name: { type: string, minLength: 1, maxLength: 100 }
+        dose: { type: string, minLength: 1, maxLength: 50 }
+        category: { $ref: '#/components/schemas/MedicationCategory' }
+        active: { type: boolean }
+        notificationsEnabled: { type: boolean }
+        schedules:
+          type: array
+          items: { $ref: '#/components/schemas/MedicationScheduleInput' }
+
+    MedicationIntakeEvent:
+      type: object
+      properties:
+        id: { type: string }
+        userId: { type: string }
+        medicationId: { type: string }
+        scheduledFor: { type: string, format: date-time }
+        takenAt: { type: [string, 'null'], format: date-time }
+        skipped: { type: boolean }
+        source: { $ref: '#/components/schemas/IntakeSource' }
+        idempotencyKey: { type: [string, 'null'] }
+        createdAt: { type: string, format: date-time }
+      required: [id, userId, medicationId, scheduledFor, skipped, source, createdAt]
+
+    CreateIntakeInput:
+      type: object
+      properties:
+        scheduledFor: { type: string, format: date-time }
+        takenAt: { type: string, format: date-time }
+        skipped: { type: boolean, default: false }
+        idempotencyKey: { type: string, maxLength: 128 }
+
+    UpdateIntakeInput:
+      type: object
+      properties:
+        takenAt: { type: [string, 'null'], format: date-time }
+        skipped: { type: boolean }
+        scheduledFor: { type: string, format: date-time }
+
+    IntakeImportEntry:
+      type: object
+      properties:
+        datum:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: YYYY-MM-DD
+        uhrzeit:
+          type: string
+          pattern: '^\d{2}:\d{2}:\d{2}$'
+          description: HH:mm:ss
+        zaehler:
+          oneOf:
+            - { type: integer }
+            - { type: string }
+      required: [datum, uhrzeit]
+
+    IntakeImportResult:
+      type: object
+      properties:
+        imported: { type: integer }
+        skippedDuplicates: { type: integer }
+        skippedInvalid: { type: integer }
+
+    ExternalIntakeInput:
+      type: object
+      properties:
+        medicationName: { type: string, maxLength: 200 }
+        takenAt: { type: string, format: date-time }
+        idempotencyKey: { type: string, maxLength: 128 }
+      required: [medicationName, idempotencyKey]
+
+    DailyComplianceEntry:
+      type: object
+      properties:
+        expected: { type: integer }
+        taken: { type: integer }
+        skipped: { type: integer }
+        onTime: { type: integer }
+        late: { type: integer }
+        veryLate: { type: integer }
+
+    ComplianceSummary:
+      type: object
+      properties:
+        rate: { type: number, description: 'Fraction 0..1' }
+        taken: { type: integer }
+        skipped: { type: integer }
+        missed: { type: integer }
+        streak: { type: integer }
+
+    MedicationComplianceResponse:
+      type: object
+      properties:
+        compliance7: { $ref: '#/components/schemas/ComplianceSummary' }
+        compliance30: { $ref: '#/components/schemas/ComplianceSummary' }
+        dailyCompliance:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/DailyComplianceEntry' }
+
+    ReminderPhaseConfig:
+      type: object
+      properties:
+        greenValue: { type: integer, default: 60 }
+        greenMode: { allOf: [{ $ref: '#/components/schemas/PhaseMode' }], default: MINUTES }
+        yellowValue: { type: integer, default: 30 }
+        yellowMode: { allOf: [{ $ref: '#/components/schemas/PhaseMode' }], default: MINUTES }
+        orangeValue: { type: integer, default: 0 }
+        orangeMode: { allOf: [{ $ref: '#/components/schemas/PhaseMode' }], default: MINUTES }
+        redValue: { type: integer, default: 240 }
+        redMode: { allOf: [{ $ref: '#/components/schemas/PhaseMode' }], default: MINUTES }
+
+    MedicationApiEndpointResponse:
+      type: object
+      properties:
+        enabled: { type: boolean }
+        activeTokenCount: { type: integer }
+        token:
+          type: [string, 'null']
+          description: 'Plaintext token, only returned once on creation.'
+        created: { type: boolean }
+        revokedTokenCount: { type: integer }
+
+    IntakeSummaryPoint:
+      type: object
+      properties:
+        date:
+          type: string
+          description: YYYY-MM-DD (Berlin local).
+        total: { type: integer }
+        medications:
+          type: object
+          additionalProperties: { type: integer }
+      required: [date, total]
+
+    IntakeSummaryResponse:
+      type: object
+      properties:
+        points:
+          type: array
+          items: { $ref: '#/components/schemas/IntakeSummaryPoint' }
+        medications:
+          type: array
+          items: { type: string }
+
+    # ─── Mood DTOs ─────────────────────────────────────────────
+    MoodEntry:
+      type: object
+      properties:
+        id: { type: string }
+        userId: { type: string }
+        date:
+          type: string
+          description: YYYY-MM-DD
+        mood: { $ref: '#/components/schemas/MoodLevel' }
+        score:
+          type: integer
+          minimum: 1
+          maximum: 5
+        tags:
+          type: array
+          items: { type: string }
+        source: { type: string, default: MANUAL }
+        moodLoggedAt: { type: string, format: date-time }
+        syncedAt: { type: string, format: date-time }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+      required: [id, userId, date, mood, score, source, moodLoggedAt]
+
+    CreateMoodEntryInput:
+      type: object
+      properties:
+        mood: { $ref: '#/components/schemas/MoodLevel' }
+        moodLoggedAt: { type: string, format: date-time }
+        tags:
+          type: array
+          items: { type: string }
+        source: { type: string }
+      required: [mood, moodLoggedAt]
+
+    UpdateMoodEntryInput:
+      type: object
+      properties:
+        mood: { $ref: '#/components/schemas/MoodLevel' }
+        moodLoggedAt: { type: string, format: date-time }
+        tags:
+          type: array
+          items: { type: string }
+
+    MoodAnalytics:
+      type: object
+      properties:
+        entries:
+          type: array
+          items:
+            type: object
+            properties:
+              date: { type: string }
+              score: { type: number }
+              samples: { type: integer }
+        summary:
+          type: object
+          additionalProperties: true
+
+    # ─── Dashboard DTOs ────────────────────────────────────────
+    DashboardWidget:
+      type: object
+      properties:
+        id:
+          type: string
+          enum: [weight, bp, pulse, bodyFat, mood, medications, sleep, steps, glucose, bpInTarget]
+        visible: { type: boolean }
+        order: { type: integer, minimum: 0, maximum: 99 }
+      required: [id, visible, order]
+
+    DashboardLayout:
+      type: object
+      properties:
+        version: { type: integer, enum: [1] }
+        widgets:
+          type: array
+          minItems: 1
+          maxItems: 20
+          items: { $ref: '#/components/schemas/DashboardWidget' }
+      required: [version, widgets]
+
+    # ─── Insights DTOs ─────────────────────────────────────────
+    Classification:
+      type: object
+      properties:
+        category: { type: string }
+        color: { type: string }
+        severity: { $ref: '#/components/schemas/InsightSeverity' }
+
+    SummaryStats:
+      type: object
+      properties:
+        latest: { type: [number, 'null'] }
+        avg7: { type: [number, 'null'] }
+        avg30: { type: [number, 'null'] }
+        min: { type: [number, 'null'] }
+        max: { type: [number, 'null'] }
+        count: { type: integer }
+        slope30:
+          type: [object, 'null']
+          properties:
+            slope: { type: number }
+            r2: { type: number }
+        anomalyCount: { type: integer }
+
+    CorrelationResult:
+      type: [object, 'null']
+      properties:
+        r: { type: number }
+        strength: { type: string }
+        n: { type: integer }
+
+    Alert:
+      type: object
+      properties:
+        severity: { $ref: '#/components/schemas/InsightSeverity' }
+        message: { type: string }
+        type: { type: string }
+
+    BpTargets:
+      type: [object, 'null']
+      properties:
+        sysLow: { type: integer }
+        sysHigh: { type: integer }
+        diaLow: { type: integer }
+        diaHigh: { type: integer }
+
+    ComprehensiveInsights:
+      type: object
+      properties:
+        summaries:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/SummaryStats' }
+        bmi: { type: [number, 'null'] }
+        bmiClassification:
+          oneOf:
+            - $ref: '#/components/schemas/Classification'
+            - type: 'null'
+        bpClassification:
+          oneOf:
+            - $ref: '#/components/schemas/Classification'
+            - type: 'null'
+        bpPctInTarget: { type: [integer, 'null'] }
+        bpTargets: { $ref: '#/components/schemas/BpTargets' }
+        weightBpCorrelation: { $ref: '#/components/schemas/CorrelationResult' }
+        scatterData:
+          type: array
+          items:
+            type: object
+            properties:
+              weight: { type: number }
+              sysBP: { type: number }
+        bpMedicationCorrelation:
+          type: [object, 'null']
+          properties:
+            r: { type: number }
+            strength: { type: string }
+            n: { type: integer }
+            medicationCount: { type: integer }
+        bpMedicationScatterData:
+          type: array
+          items:
+            type: object
+            properties:
+              continuityPct: { type: integer }
+              sysBP: { type: number }
+        moodSummary:
+          oneOf:
+            - $ref: '#/components/schemas/SummaryStats'
+            - type: 'null'
+        moodBpCorrelation: { $ref: '#/components/schemas/CorrelationResult' }
+        moodBpScatterData:
+          type: array
+          items:
+            type: object
+            properties:
+              mood: { type: number }
+              sysBP: { type: number }
+        moodWeightCorrelation: { $ref: '#/components/schemas/CorrelationResult' }
+        moodWeightScatterData:
+          type: array
+          items:
+            type: object
+            properties:
+              mood: { type: number }
+              weight: { type: number }
+        moodPulseCorrelation: { $ref: '#/components/schemas/CorrelationResult' }
+        moodPulseScatterData:
+          type: array
+          items:
+            type: object
+            properties:
+              mood: { type: number }
+              pulse: { type: number }
+        medications:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: string }
+              name: { type: string }
+              dose: { type: string }
+              category: { $ref: '#/components/schemas/MedicationCategory' }
+              compliance7: { type: number }
+              compliance30: { type: number }
+              streak: { type: integer }
+              taken7: { type: integer }
+              skipped7: { type: integer }
+              missed7: { type: integer }
+        alerts:
+          type: array
+          items: { $ref: '#/components/schemas/Alert' }
+        hasProvider: { type: boolean }
+        dataSpanDays: { type: integer }
+        totalMeasurements: { type: integer }
+
+    InsightTargetItem:
+      type: object
+      properties:
+        type: { type: string }
+        label: { type: string }
+        current: { type: [number, 'null'] }
+        average30: { type: [number, 'null'] }
+        trend: { $ref: '#/components/schemas/Trend' }
+        unit: { type: string }
+        range:
+          type: [object, 'null']
+          properties:
+            min: { type: number }
+            max: { type: number }
+        classification:
+          oneOf:
+            - $ref: '#/components/schemas/Classification'
+            - type: 'null'
+        source: { type: string }
+        details:
+          type: object
+          properties:
+            medications:
+              type: array
+              items:
+                type: object
+                properties:
+                  name: { type: string }
+                  compliance7: { type: number }
+                  compliance30: { type: number }
+
+    InsightTargetsResponse:
+      type: object
+      properties:
+        targets:
+          type: array
+          items: { $ref: '#/components/schemas/InsightTargetItem' }
+        bpDiastolic:
+          type: object
+          properties:
+            current: { type: [number, 'null'] }
+            average30: { type: [number, 'null'] }
+            range:
+              type: [object, 'null']
+              properties:
+                min: { type: number }
+                max: { type: number }
+        profile:
+          type: object
+          properties:
+            heightCm: { type: [number, 'null'] }
+            age: { type: [integer, 'null'] }
+            gender:
+              oneOf:
+                - $ref: '#/components/schemas/Gender'
+                - type: 'null'
+            glucoseUnit: { type: string }
+
+    InsightStatusBundle:
+      type: object
+      description: Narrative status payload (shape varies per status route).
+      additionalProperties: true
+
+    InsightGenerateResult:
+      type: object
+      properties:
+        insights:
+          type: object
+          additionalProperties: true
+        cached: { type: boolean }
+        cachedAt: { type: string, format: date-time }
+
+    InsightsSettings:
+      type: object
+      properties:
+        codexStatus: { type: string, enum: [connected, disconnected] }
+        codexConnectedAt: { type: [string, 'null'], format: date-time }
+        hasAdminKey: { type: boolean }
+        privacyMode: { type: string, enum: [aggregated, raw] }
+        lastInsightAt: { type: [string, 'null'], format: date-time }
+
+    # ─── Achievements ──────────────────────────────────────────
+    Achievement:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        target: { type: integer }
+        progress: { type: integer }
+        unlocked: { type: boolean }
+        completedAt:
+          type: [string, 'null']
+          format: date-time
+
+    AchievementsResult:
+      type: object
+      properties:
+        achievements:
+          type: array
+          items: { $ref: '#/components/schemas/Achievement' }
+        unlockedCount: { type: integer }
+        totalCount: { type: integer }
+
+    # ─── Doctor report ─────────────────────────────────────────
+    DoctorReportResponse:
+      type: object
+      properties:
+        period:
+          type: object
+          properties:
+            days: { type: integer }
+            since: { type: string, format: date-time }
+        patient:
+          type: object
+          properties:
+            username: { type: [string, 'null'] }
+            dateOfBirth: { type: [string, 'null'], format: date-time }
+            gender:
+              oneOf:
+                - $ref: '#/components/schemas/Gender'
+                - type: 'null'
+            heightCm: { type: [number, 'null'] }
+        measurements:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              properties:
+                value: { type: number }
+                measuredAt: { type: string, format: date-time }
+        stats:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              avg: { type: number }
+              min: { type: number }
+              max: { type: number }
+              count: { type: integer }
+              latest: { type: number }
+        glucoseStats:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              avg: { type: number }
+              min: { type: number }
+              max: { type: number }
+              count: { type: integer }
+              latest: { type: number }
+        glucoseRanges:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              min: { type: number }
+              max: { type: number }
+        glucoseUnit: { type: string }
+        bmi: { type: [number, 'null'] }
+        compliance:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              total: { type: integer }
+              taken: { type: integer }
+              skipped: { type: integer }
+              missed: { type: integer }
+        medications:
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string }
+              dose: { type: string }
+              schedules:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    windowStart: { type: string }
+                    windowEnd: { type: string }
+                    label: { type: [string, 'null'] }
+        mood:
+          type: [object, 'null']
+          properties:
+            avg: { type: number }
+            min: { type: number }
+            max: { type: number }
+            count: { type: integer }
+            distribution:
+              type: object
+              additionalProperties: { type: integer }
+
+    # ─── Onboarding ────────────────────────────────────────────
+    OnboardingInput:
+      type: object
+      properties:
+        heightCm: { type: number, minimum: 50, maximum: 300 }
+        dateOfBirth: { type: string, format: date }
+        gender: { $ref: '#/components/schemas/Gender' }
+
+    # ─── Health probe ──────────────────────────────────────────
+    HealthStatus:
+      type: object
+      properties:
+        status: { type: string, enum: [ok, degraded] }
+        timestamp: { type: string, format: date-time }
+        database: { type: string }
+        worker: { type: string }
+        workerLastHeartbeat: { type: string, format: date-time }
+
+    # ─── Tokens ────────────────────────────────────────────────
+    ApiTokenSummary:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        permissions:
+          type: array
+          items: { type: string }
+        lastUsedAt: { type: [string, 'null'], format: date-time }
+        expiresAt: { type: [string, 'null'], format: date-time }
+        createdAt: { type: string, format: date-time }
+        revoked: { type: boolean }
+
+    CreateTokenInput:
+      type: object
+      properties:
+        name: { type: string, minLength: 1, maxLength: 100 }
+        expiresInDays: { type: integer, minimum: 1, maximum: 365 }
+      required: [name]
+
+    # ─── Notifications ─────────────────────────────────────────
+    NotificationChannel:
+      type: object
+      properties:
+        id: { type: string }
+        type: { $ref: '#/components/schemas/NotificationChannelType' }
+        label: { type: string }
+        enabled: { type: boolean }
+        globallyEnabled: { type: boolean }
+
+    NotificationPreference:
+      type: object
+      properties:
+        channelId: { type: string }
+        eventType: { type: string }
+        enabled: { type: boolean }
+
+    NotificationPreferencesResponse:
+      type: object
+      properties:
+        channels:
+          type: array
+          items: { $ref: '#/components/schemas/NotificationChannel' }
+        preferences:
+          type: array
+          items: { $ref: '#/components/schemas/NotificationPreference' }
+        eventTypes:
+          type: array
+          items: { type: string }
+
+    UpdateNotificationPreferenceInput:
+      type: object
+      properties:
+        channelId: { type: string }
+        eventType: { type: string }
+        enabled: { type: boolean }
+      required: [channelId, eventType, enabled]
+
+    WebPushSubscribeInput:
+      type: object
+      properties:
+        endpoint: { type: string, format: uri }
+        keys:
+          type: object
+          properties:
+            p256dh: { type: string }
+            auth: { type: string }
+          required: [p256dh, auth]
+      required: [endpoint, keys]
+
+    # ─── User config ───────────────────────────────────────────
+    UserAiProvider:
+      type: object
+      properties:
+        provider:
+          oneOf:
+            - $ref: '#/components/schemas/AiProviderType'
+            - type: 'null'
+        model: { type: [string, 'null'] }
+        baseUrl: { type: [string, 'null'] }
+        hasAnthropicKey: { type: boolean }
+        anthropicKeyPreview: { type: [string, 'null'] }
+        hasLocalKey: { type: boolean }
+
+    UpdateUserAiProviderInput:
+      type: object
+      properties:
+        provider:
+          oneOf:
+            - $ref: '#/components/schemas/AiProviderType'
+            - type: 'null'
+        model: { type: [string, 'null'] }
+        baseUrl: { type: [string, 'null'] }
+        anthropicKey: { type: [string, 'null'] }
+        localKey: { type: [string, 'null'] }
+
+    ThresholdRange:
+      type: object
+      properties:
+        greenMin: { type: number }
+        greenMax: { type: number }
+        orangeMin: { type: number }
+        orangeMax: { type: number }
+        redMin: { type: number }
+        redMax: { type: number }
+
+    EffectiveRange:
+      type: object
+      properties:
+        range:
+          oneOf:
+            - $ref: '#/components/schemas/ThresholdRange'
+            - type: 'null'
+        isOverride: { type: boolean }
+        defaultRange:
+          oneOf:
+            - $ref: '#/components/schemas/ThresholdRange'
+            - type: 'null'
+
+    ThresholdOverrides:
+      type: object
+      description: 'Map of metric name → `{ min, max }` override.'
+      additionalProperties:
+        type: object
+        properties:
+          min: { type: number }
+          max: { type: number }
+
+    ThresholdsResponse:
+      type: object
+      properties:
+        effective:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/EffectiveRange' }
+        overrides: { $ref: '#/components/schemas/ThresholdOverrides' }
+
+    # ─── Analytics ─────────────────────────────────────────────
+    AnalyticsResponse:
+      type: object
+      properties:
+        summaries:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/SummaryStats' }
+        bmi: { type: [number, 'null'] }
+        bpInTargetPct: { type: [integer, 'null'] }
+        glucoseByContext:
+          type: object
+          additionalProperties: { $ref: '#/components/schemas/SummaryStats' }
+
+    AiTestResult:
+      type: object
+      properties:
+        ok: { type: boolean }
+        providerType: { $ref: '#/components/schemas/AiProviderType' }
+        model: { type: string }
+        tokensUsed:
+          type: object
+          properties:
+            input: { type: integer }
+            output: { type: integer }
+        sample: { type: string }
+
+    # ─── Export / Import ───────────────────────────────────────
+    ImportInput:
+      type: object
+      properties:
+        measurements:
+          type: array
+          maxItems: 10000
+          items:
+            type: object
+            properties:
+              type: { $ref: '#/components/schemas/MeasurementType' }
+              value: { type: number }
+              unit: { type: string }
+              measuredAt: { type: string, format: date-time }
+              source: { type: string }
+              notes: { type: string }
+            required: [type, value, unit, measuredAt]
+        moodEntries:
+          type: array
+          maxItems: 10000
+          items:
+            type: object
+            properties:
+              date: { type: string }
+              mood: { $ref: '#/components/schemas/MoodLevel' }
+              score: { type: integer, minimum: 1, maximum: 5 }
+              tags: { type: string }
+              loggedAt: { type: string, format: date-time }
+            required: [date, mood, score]
+
+    ImportResult:
+      type: object
+      properties:
+        measurements: { type: integer }
+        moodEntries: { type: integer }
+        skipped: { type: integer }
+
+    # ─── Audit log ─────────────────────────────────────────────
+    AuditLogEntry:
+      type: object
+      properties:
+        id: { type: string }
+        action: { type: string }
+        ipAddress: { type: [string, 'null'] }
+        location: { type: [string, 'null'] }
+        details: { type: [string, 'null'], description: 'JSON string' }
+        createdAt: { type: string, format: date-time }
+
+    AuditLogResponse:
+      type: object
+      properties:
+        entries:
+          type: array
+          items: { $ref: '#/components/schemas/AuditLogEntry' }
+        meta: { $ref: '#/components/schemas/PageMeta' }
+
+    # ─── Feedback ──────────────────────────────────────────────
+    FeedbackCategory:
+      type: string
+      enum: [BUG, FEATURE_REQUEST, QUESTION, OTHER]
+
+    FeedbackStatus:
+      type: string
+      enum: [OPEN, ACKNOWLEDGED, RESOLVED, ARCHIVED]
+
+    FeedbackSummary:
+      type: object
+      properties:
+        id: { type: string }
+        category: { $ref: '#/components/schemas/FeedbackCategory' }
+        subject: { type: string }
+        status: { $ref: '#/components/schemas/FeedbackStatus' }
+        adminNote: { type: [string, 'null'] }
+        gitHubIssueUrl: { type: [string, 'null'], format: uri }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    CreateFeedbackInput:
+      type: object
+      properties:
+        category: { $ref: '#/components/schemas/FeedbackCategory' }
+        subject: { type: string }
+        description: { type: string }
+        screenshot:
+          type: string
+          description: 'Base64-encoded PNG/JPG (≤5 MB).'
+        metadata:
+          type: object
+          additionalProperties: true
+      required: [category, subject, description]
+
+    BugReportInput:
+      type: object
+      properties:
+        description: { type: string, minLength: 10, maxLength: 5000 }
+        screenshot:
+          type: string
+          description: '`data:image/(png|jpeg|webp|gif);base64,...` data URL.'
+      required: [description]
+
+    # ─── Settings ──────────────────────────────────────────────
+    GlobalServicesFlags:
+      type: object
+      properties:
+        telegram: { type: boolean }
+        ntfy: { type: boolean }
+        webPush: { type: boolean }
+        api: { type: boolean }
+        moodLog: { type: boolean }
+
+    MoodLogSettingsInput:
+      type: object
+      properties:
+        url: { type: [string, 'null'], format: uri }
+        apiKey: { type: [string, 'null'] }
+        enabled: { type: boolean }
+        webhookSecret: { type: [string, 'null'] }
+
+    NtfySettings:
+      type: object
+      properties:
+        configured: { type: boolean }
+        enabled: { type: boolean }
+        topic: { type: [string, 'null'] }
+        serverUrl: { type: [string, 'null'] }
+
+    NtfySettingsInput:
+      type: object
+      properties:
+        topic: { type: [string, 'null'] }
+        serverUrl: { type: [string, 'null'], format: uri }
+        enabled: { type: boolean }
+        accessToken: { type: [string, 'null'] }
+
+    TelegramSettings:
+      type: object
+      properties:
+        configured: { type: boolean }
+        enabled: { type: boolean }
+        chatId: { type: [string, 'null'] }
+
+    TelegramSettingsInput:
+      type: object
+      properties:
+        botToken: { type: [string, 'null'] }
+        chatId: { type: [string, 'null'] }
+        enabled: { type: boolean }
+
+    ReminderThresholds:
+      type: object
+      properties:
+        reminderLateMinutes: { type: integer }
+        reminderMissedMinutes: { type: integer }
+
+    # ─── Withings + moodLog status ─────────────────────────────
+    WithingsCredentialsInput:
+      type: object
+      properties:
+        clientId: { type: string }
+        clientSecret: { type: string }
+      required: [clientId, clientSecret]
+
+    WithingsStatus:
+      type: object
+      properties:
+        connected: { type: boolean }
+        configured: { type: boolean }
+        lastSyncedAt: { type: [string, 'null'], format: date-time }
+        connectedAt: { type: string, format: date-time }
+        tokenExpired: { type: boolean }
+        tokenRefreshFailed: { type: boolean }
+        tokenExpiresAt: { type: string, format: date-time }
+
+    MoodLogStatus:
+      type: object
+      properties:
+        configured: { type: boolean }
+        enabled: { type: boolean }
+        lastSyncedAt: { type: [string, 'null'], format: date-time }
+        entryCount: { type: integer }
+        webhookSecret: { type: [string, 'null'] }
+
+    PublicMonitoringSettings:
+      type: object
+      properties:
+        umamiEnabled: { type: boolean }
+        umamiScriptUrl: { type: [string, 'null'] }
+        umamiWebsiteId: { type: [string, 'null'] }
+        glitchtipEnabled: { type: boolean }
+        glitchtipDsn: { type: [string, 'null'] }
+        glitchtipEnvironment: { type: [string, 'null'] }
+
+    # ─── iOS adapter DTOs (v1.3) ──────────────────────────────
+    MetricKind:
+      type: string
+      enum:
+        - weight
+        - bloodPressure
+        - pulse
+        - bodyFat
+        - glucose
+        - sleep
+        - steps
+
+    InsightSeverityIos:
+      type: string
+      enum: [alert, caution, info, good]
+
+    DashboardSummaryGreeting:
+      type: object
+      properties:
+        salutation: { type: string }
+        date: { type: string, format: date-time }
+      required: [salutation, date]
+
+    DashboardSummaryStreak:
+      type: object
+      properties:
+        currentDays: { type: integer }
+        longest: { type: integer }
+        label: { type: string }
+      required: [currentDays, longest, label]
+
+    DashboardSummaryCompliance:
+      type: object
+      properties:
+        scheduledToday: { type: integer }
+        takenToday: { type: integer }
+      required: [scheduledToday, takenToday]
+
+    DashboardMetricCard:
+      type: object
+      properties:
+        id: { type: string }
+        kind: { $ref: '#/components/schemas/MetricKind' }
+        title: { type: string }
+        latestValue: { type: [number, 'null'] }
+        secondaryValue: { type: [number, 'null'] }
+        unit: { type: string }
+        trend:
+          type: string
+          enum: [up, down, flat, unknown]
+        sparkline:
+          type: array
+          items: { type: number }
+        updatedAt: { type: [string, 'null'], format: date-time }
+      required: [id, kind, title, unit, trend, sparkline]
+
+    DashboardSummary:
+      type: object
+      properties:
+        greeting: { $ref: '#/components/schemas/DashboardSummaryGreeting' }
+        streak: { $ref: '#/components/schemas/DashboardSummaryStreak' }
+        compliance: { $ref: '#/components/schemas/DashboardSummaryCompliance' }
+        highlightInsight:
+          oneOf:
+            - { type: 'null' }
+            - { $ref: '#/components/schemas/InsightCard' }
+        metrics:
+          type: array
+          items: { $ref: '#/components/schemas/DashboardMetricCard' }
+        lastUpdated: { type: string, format: date-time }
+      required: [greeting, streak, compliance, metrics, lastUpdated]
+
+    MeasurementSeriesPoint:
+      type: object
+      properties:
+        id: { type: string }
+        at: { type: string, format: date-time }
+        value: { type: number }
+        secondary: { type: [number, 'null'] }
+      required: [id, at, value]
+
+    MeasurementSeriesStats:
+      type: object
+      properties:
+        mean: { type: number }
+        min: { type: number }
+        max: { type: number }
+        stdDev: { type: number }
+        count: { type: integer }
+      required: [mean, min, max, stdDev, count]
+
+    MeasurementSeries:
+      type: object
+      properties:
+        kind: { $ref: '#/components/schemas/MetricKind' }
+        points:
+          type: array
+          items: { $ref: '#/components/schemas/MeasurementSeriesPoint' }
+        stats: { $ref: '#/components/schemas/MeasurementSeriesStats' }
+      required: [kind, points, stats]
+
+    HealthKitDirection:
+      type: string
+      enum: [bidirectional, readOnly, writeOnly, disabled]
+
+    HealthKitEntry:
+      type: object
+      properties:
+        id: { type: string }
+        kind: { type: string }
+        direction: { $ref: '#/components/schemas/HealthKitDirection' }
+        enabled: { type: boolean }
+      required: [id, kind, direction, enabled]
+
+    HealthKitConfig:
+      type: object
+      properties:
+        entries:
+          type: array
+          items: { $ref: '#/components/schemas/HealthKitEntry' }
+        lastSyncedAt: { type: [string, 'null'], format: date-time }
+      required: [entries]
+
+    HealthKitConfigPatch:
+      type: object
+      properties:
+        entries:
+          type: array
+          maxItems: 50
+          items:
+            type: object
+            properties:
+              id: { type: string }
+              kind: { type: string }
+              direction: { $ref: '#/components/schemas/HealthKitDirection' }
+              enabled: { type: boolean }
+            required: [id, direction]
+      required: [entries]
+
+    IosUserProfile:
+      type: object
+      properties:
+        username: { type: string }
+        displayName: { type: [string, 'null'] }
+        email: { type: [string, 'null'], format: email }
+        dateOfBirth: { type: [string, 'null'], format: date-time }
+        gender: { $ref: '#/components/schemas/Gender' }
+        heightCm: { type: [number, 'null'] }
+        locale: { type: [string, 'null'] }
+        timezone: { type: string }
+      required: [username, timezone]
+
+    IosUserProfilePatch:
+      type: object
+      properties:
+        displayName: { type: [string, 'null'], minLength: 1, maxLength: 80 }
+        email: { type: [string, 'null'], format: email }
+        dateOfBirth: { type: [string, 'null'] }
+        gender:
+          oneOf:
+            - { type: 'null' }
+            - { $ref: '#/components/schemas/Gender' }
+        heightCm: { type: [number, 'null'], minimum: 50, maximum: 300 }
+        locale:
+          type: [string, 'null']
+          enum: [de, en, null]
+        timezone: { type: string, minLength: 1, maxLength: 64 }
+
+    DeviceRegisterInput:
+      type: object
+      properties:
+        token: { type: string, minLength: 8, maxLength: 512 }
+        bundleId: { type: string, minLength: 1, maxLength: 128 }
+        locale: { type: string }
+        appVersion: { type: string }
+        model: { type: string }
+      required: [token, bundleId]
+
+    IntakeUpdateInput:
+      type: object
+      properties:
+        intakeId: { type: string }
+        status:
+          type: string
+          enum: [taken, skipped, snoozed]
+        takenAt: { type: string, format: date-time }
+        snoozedUntil: { type: string, format: date-time }
+      required: [intakeId, status]
+
+    InsightRecommendation:
+      type: object
+      properties:
+        id: { type: string }
+        label: { type: string }
+        actionURL: { type: [string, 'null'] }
+      required: [id, label]
+
+    InsightCard:
+      type: object
+      properties:
+        id: { type: string }
+        title: { type: string }
+        summary: { type: string }
+        body: { type: [string, 'null'] }
+        severity: { $ref: '#/components/schemas/InsightSeverityIos' }
+        recommendations:
+          type: array
+          items: { $ref: '#/components/schemas/InsightRecommendation' }
+        generatedAt: { type: string, format: date-time }
+        provider: { type: string }
+      required: [id, title, summary, severity, recommendations, generatedAt, provider]
+
+    InsightCorrelation:
+      type: object
+      properties:
+        id: { type: string }
+        leftMetric: { type: string }
+        rightMetric: { type: string }
+        coefficient: { type: number }
+        sampleSize: { type: integer }
+      required: [id, leftMetric, rightMetric, coefficient, sampleSize]
+
+    # ─── Admin DTOs ────────────────────────────────────────────
+    AdminUpdateUserInput:
+      type: object
+      properties:
+        username: { type: string, minLength: 3, maxLength: 30 }
+        email: { type: [string, 'null'], format: email }
+        role: { $ref: '#/components/schemas/UserRole' }

--- a/docs/doctor-report.md
+++ b/docs/doctor-report.md
@@ -1,0 +1,57 @@
+# Doctor Report
+
+The doctor report is a printable PDF summary of a user's tracked vitals,
+medication compliance, glucose context, and mood over a configurable window
+(default 90 days, max 365). It is intended as discussion material for a
+doctor's appointment, **not** a medical diagnosis.
+
+## Two endpoints
+
+The same aggregation logic backs both endpoints — `collectDoctorReportData`
+in `src/lib/doctor-report-data.ts` is the single source of truth — so the
+JSON payload and the server-rendered PDF are guaranteed to be in sync.
+
+### `POST /api/doctor-report` — JSON payload
+
+Returns the aggregated `DoctorReportData` envelope. Used by the PWA's
+client-side renderer (`src/lib/doctor-report-pdf.ts`, jsPDF + autotable).
+Best on desktop browsers and on Android, where local generation keeps the
+PDF off the wire and works offline (cached page).
+
+- Auth: session required.
+- Rate-limit: 10/h per user.
+- Body: `{ days?: number }` (default 90).
+- Response: `200 application/json` with envelope `{ data, error: null }`.
+- Audit action: `doctor-report.generate`.
+
+### `POST /api/doctor-report/pdf` — server-rendered PDF
+
+Returns the ready-to-download PDF bytes. Used primarily on iOS/Safari, where
+the client-side jsPDF download UX is unreliable (Safari sometimes opens the
+PDF in a new tab without preserving the filename or fails the blob save).
+
+- Auth: session required (`401` otherwise).
+- Rate-limit: 10/h per user, shared with the JSON endpoint (`429` on excess).
+- Body: `{ days?: number; locale?: "de" | "en" }`. Body is optional — empty
+  bodies are accepted.
+- Locale resolution: explicit `body.locale` wins, then the
+  `Accept-Language` header (`de*` → `de`, anything else → `en`), then the
+  hard fallback `de`.
+- Response: `200 application/pdf` with
+  `Content-Disposition: attachment; filename="healthlog-report-YYYY-MM-DD.pdf"`
+  and `Cache-Control: no-store`. Body is the raw PDF bytes.
+- Errors: JSON envelope `{ data: null, error: "..." }` for `401` and `429`;
+  `500` if rendering fails.
+- Audit action: `doctor-report.pdf.generate`.
+
+## Implementation notes
+
+- `src/lib/doctor-report-pdf-core.ts` contains the isomorphic renderer.
+  jsPDF runs unchanged in Node — `doc.output("arraybuffer")` returns a valid
+  `%PDF-` byte stream in both environments, so we deliberately avoid headless
+  Chromium (Puppeteer/Playwright) to keep the runtime dependency surface low.
+- `src/lib/doctor-report-pdf.ts` is a thin client façade that returns the
+  raw `jsPDF` instance so the existing settings-page download flow (which
+  calls `doc.save(...)`) keeps working unchanged.
+- Server-side translations come from `messages/{de,en}.json` via
+  `getServerTranslator()` (`src/lib/i18n/server-translator.ts`).

--- a/prisma/migrations/0023_ios_adapters_idempotency_devices/migration.sql
+++ b/prisma/migrations/0023_ios_adapters_idempotency_devices/migration.sql
@@ -1,0 +1,55 @@
+-- v1.3: iOS adapter endpoints + idempotency cache + device registration
+--
+-- Purely additive:
+--   • users.display_name, users.healthkit_config_json, users.healthkit_last_synced_at
+--   • new tables: idempotency_keys, devices
+
+-- ── users new columns ─────────────────────────────────────────────────
+
+ALTER TABLE "users"
+  ADD COLUMN "display_name" TEXT,
+  ADD COLUMN "healthkit_config_json" JSONB,
+  ADD COLUMN "healthkit_last_synced_at" TIMESTAMP(3);
+
+-- ── idempotency_keys ──────────────────────────────────────────────────
+
+CREATE TABLE "idempotency_keys" (
+  "id"              TEXT PRIMARY KEY,
+  "user_id"         TEXT NOT NULL,
+  "key"             TEXT NOT NULL,
+  "method"          TEXT NOT NULL,
+  "path"            TEXT NOT NULL,
+  "response_status" INTEGER NOT NULL,
+  "response_body"   TEXT NOT NULL,
+  "expires_at"      TIMESTAMP(3) NOT NULL,
+  "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "idempotency_keys_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "idempotency_keys_user_id_key_method_path_key"
+  ON "idempotency_keys" ("user_id", "key", "method", "path");
+
+CREATE INDEX "idempotency_keys_expires_at_idx"
+  ON "idempotency_keys" ("expires_at");
+
+-- ── devices ───────────────────────────────────────────────────────────
+
+CREATE TABLE "devices" (
+  "id"          TEXT PRIMARY KEY,
+  "user_id"     TEXT NOT NULL,
+  "platform"    TEXT NOT NULL,
+  "token"       TEXT NOT NULL,
+  "bundle_id"   TEXT NOT NULL,
+  "locale"      TEXT,
+  "app_version" TEXT,
+  "model"       TEXT,
+  "last_seen"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "created_at"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"  TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "devices_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "devices_token_key" ON "devices" ("token");
+CREATE INDEX "devices_user_id_idx" ON "devices" ("user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,14 @@ model User {
   // Onboarding
   onboardingCompletedAt DateTime? @map("onboarding_completed_at")
 
+  // HealthKit (iOS) integration config — list of per-metric direction toggles.
+  // Shape: { entries: [{ id, kind, direction, enabled }], lastSyncedAt }
+  healthKitConfigJson Json?     @map("healthkit_config_json")
+  healthKitLastSyncedAt DateTime? @map("healthkit_last_synced_at")
+
+  // Display name (optional override of username for greetings).
+  displayName String? @map("display_name")
+
   // Relations
   passkeys    Passkey[]
   sessions    Session[]
@@ -90,6 +98,8 @@ model User {
   dataBackups          DataBackup[]
   achievements         UserAchievement[]
   feedback             Feedback[]
+  idempotencyKeys      IdempotencyKey[]
+  devices              Device[]
 
   @@map("users")
 }
@@ -557,6 +567,52 @@ model RateLimit {
 
   @@index([resetAt])
   @@map("rate_limits")
+}
+
+// ─── Idempotency Keys (mobile-client replay protection) ──
+
+/// Caches the response of a POST/PUT/PATCH/DELETE request keyed by
+/// (userId, key, method, path) so retries within the TTL replay the
+/// original outcome instead of producing a duplicate side-effect.
+model IdempotencyKey {
+  id             String   @id @default(cuid())
+  userId         String   @map("user_id")
+  key            String
+  method         String
+  path           String
+  responseStatus Int      @map("response_status")
+  responseBody   String   @map("response_body") // serialized JSON envelope
+  expiresAt      DateTime @map("expires_at")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, key, method, path])
+  @@index([expiresAt])
+  @@map("idempotency_keys")
+}
+
+// ─── Devices (APNs / mobile push targets) ────────────────
+
+/// Registered native-client device for push delivery. Token is unique
+/// across users; re-registering on a different account moves ownership.
+model Device {
+  id          String   @id @default(cuid())
+  userId      String   @map("user_id")
+  platform    String   // "ios"
+  token       String   @unique
+  bundleId    String   @map("bundle_id")
+  locale      String?
+  appVersion  String?  @map("app_version")
+  model       String?
+  lastSeen    DateTime @default(now()) @map("last_seen")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("devices")
 }
 
 // ─── User Achievements ───────────────────────────────────────

--- a/src/app/api/auth/login/__tests__/native-token.test.ts
+++ b/src/app/api/auth/login/__tests__/native-token.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// --- Mocks must come before importing the route. ---
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: { findFirst: vi.fn() },
+    apiToken: { create: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/password", () => ({
+  verifyPassword: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  createSession: vi.fn().mockResolvedValue("session-id"),
+}));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 5, reset: 0 }),
+  rateLimitHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/auth/hmac", () => ({
+  hashToken: vi.fn(() => "deadbeef"),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({
+  emitIfSampled: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { POST } from "../route";
+import { prisma } from "@/lib/db";
+import { verifyPassword } from "@/lib/auth/password";
+import { checkRateLimit, rateLimitHeaders } from "@/lib/rate-limit";
+import { ensureDbCompatibility } from "@/lib/db-compat";
+import { auditLog } from "@/lib/auth/audit";
+import { createSession } from "@/lib/auth/session";
+
+const FAKE_USER = {
+  id: "user-1",
+  username: "marc",
+  email: "marc@example.com",
+  passwordHash: "$argon2id$...",
+};
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/auth/login", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({ email: "marc@example.com", password: "supersecret" }),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.user.findFirst).mockResolvedValue(FAKE_USER as never);
+  vi.mocked(verifyPassword).mockResolvedValue(true);
+  vi.mocked(prisma.apiToken.create).mockResolvedValue({ id: "tok-1" } as never);
+  vi.mocked(checkRateLimit).mockResolvedValue({
+    allowed: true,
+    remaining: 5,
+    reset: 0,
+  } as never);
+  vi.mocked(rateLimitHeaders).mockReturnValue({} as never);
+  vi.mocked(ensureDbCompatibility).mockResolvedValue(undefined);
+  vi.mocked(auditLog).mockResolvedValue(undefined as never);
+  vi.mocked(createSession).mockResolvedValue("session-id");
+});
+
+describe("POST /api/auth/login — native token issuance", () => {
+  it("issues a Bearer token when X-Client-Type: native is set", async () => {
+    const original = process.env.API_TOKEN_HMAC_KEY;
+    process.env.API_TOKEN_HMAC_KEY = "test-key";
+    try {
+      const res = await POST(makeRequest({ "x-client-type": "native" }));
+      const body = (await res.json()) as {
+        data: { user: { id: string }; token?: string; tokenExpiresAt?: string };
+      };
+      expect(res.status).toBe(200);
+      expect(body.data.user.id).toBe("user-1");
+      expect(body.data.token).toMatch(/^hlk_[a-f0-9]{64}$/);
+      expect(body.data.tokenExpiresAt).toEqual(expect.any(String));
+      expect(prisma.apiToken.create).toHaveBeenCalledTimes(1);
+    } finally {
+      process.env.API_TOKEN_HMAC_KEY = original;
+    }
+  });
+
+  it("does NOT issue a token without the native header", async () => {
+    const res = await POST(makeRequest());
+    const body = (await res.json()) as {
+      data: { user: { id: string }; token?: string };
+    };
+    expect(res.status).toBe(200);
+    expect(body.data.user.id).toBe("user-1");
+    expect(body.data.token).toBeUndefined();
+    expect(prisma.apiToken.create).not.toHaveBeenCalled();
+  });
+
+  it("issues a token when User-Agent starts with HealthLog-iOS", async () => {
+    const original = process.env.API_TOKEN_HMAC_KEY;
+    process.env.API_TOKEN_HMAC_KEY = "test-key";
+    try {
+      const res = await POST(
+        makeRequest({ "user-agent": "HealthLog-iOS/1.0 (iPhone)" }),
+      );
+      const body = (await res.json()) as { data: { token?: string } };
+      expect(res.status).toBe(200);
+      expect(body.data.token).toMatch(/^hlk_/);
+    } finally {
+      process.env.API_TOKEN_HMAC_KEY = original;
+    }
+  });
+});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -9,6 +9,7 @@ import { ensureDbCompatibility } from "@/lib/db-compat";
 import { NextRequest, NextResponse } from "next/server";
 import { apiHandler } from "@/lib/api-handler";
 import { annotate } from "@/lib/logging/context";
+import { issueApiToken, isNativeClientRequest } from "@/lib/auth/issue-token";
 
 export const POST = apiHandler(async (request: NextRequest) => {
   const ip = getClientIp(request) ?? "unknown";
@@ -73,6 +74,29 @@ export const POST = apiHandler(async (request: NextRequest) => {
   });
 
   annotate({ action: { name: "auth.login.password" } });
+
+  // Native clients (iOS) additionally receive a long-lived Bearer token in
+  // the response so they don't need to juggle the cookie jar.
+  if (isNativeClientRequest(request.headers)) {
+    const issued = await issueApiToken({
+      userId: user.id,
+      name: `iOS auto-login ${new Date().toISOString()}`,
+      permissions: ["*"],
+      expiresInDays: 90,
+    });
+    await auditLog("auth.token.autoissue.native", {
+      userId: user.id,
+      ipAddress: ip,
+      details: { tokenId: issued.tokenId, source: "login.password" },
+    });
+    annotate({ action: { name: "auth.token.autoissue.native" } });
+
+    return apiSuccess({
+      user: { id: user.id, username: user.username },
+      token: issued.token,
+      tokenExpiresAt: issued.expiresAt.toISOString(),
+    });
+  }
 
   return apiSuccess({
     user: { id: user.id, username: user.username },

--- a/src/app/api/auth/passkey/login-verify/__tests__/native-token.test.ts
+++ b/src/app/api/auth/passkey/login-verify/__tests__/native-token.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    apiToken: { create: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/passkey", () => ({
+  verifyAuthentication: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  createSession: vi.fn().mockResolvedValue("session-id"),
+}));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/auth/hmac", () => ({
+  hashToken: vi.fn(() => "deadbeef"),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({
+  emitIfSampled: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { POST } from "../route";
+import { prisma } from "@/lib/db";
+import { verifyAuthentication } from "@/lib/auth/passkey";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+const FAKE_USER = {
+  id: "user-1",
+  username: "marc",
+  email: "marc@example.com",
+};
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest("http://localhost/api/auth/passkey/login-verify", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({
+      challengeId: "ch-1",
+      credential: { id: "cred-1" },
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.user.findUnique).mockResolvedValue(FAKE_USER as never);
+  vi.mocked(prisma.apiToken.create).mockResolvedValue({ id: "tok-1" } as never);
+  vi.mocked(checkRateLimit).mockResolvedValue({
+    allowed: true,
+    remaining: 9,
+    reset: 0,
+  } as never);
+  vi.mocked(verifyAuthentication).mockResolvedValue({
+    verification: { verified: true },
+    passkey: { userId: "user-1" },
+  } as never);
+});
+
+describe("POST /api/auth/passkey/login-verify — native token issuance", () => {
+  it("issues a Bearer token when X-Client-Type: native is set", async () => {
+    const original = process.env.API_TOKEN_HMAC_KEY;
+    process.env.API_TOKEN_HMAC_KEY = "test-key";
+    try {
+      const res = await POST(makeRequest({ "x-client-type": "native" }));
+      const body = (await res.json()) as {
+        data: { token?: string; tokenExpiresAt?: string };
+      };
+      expect(res.status).toBe(200);
+      expect(body.data.token).toMatch(/^hlk_[a-f0-9]{64}$/);
+      expect(body.data.tokenExpiresAt).toEqual(expect.any(String));
+      expect(prisma.apiToken.create).toHaveBeenCalledTimes(1);
+    } finally {
+      process.env.API_TOKEN_HMAC_KEY = original;
+    }
+  });
+
+  it("does NOT issue a token without the native header", async () => {
+    const res = await POST(makeRequest());
+    const body = (await res.json()) as { data: { token?: string } };
+    expect(res.status).toBe(200);
+    expect(body.data.token).toBeUndefined();
+    expect(prisma.apiToken.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when verification fails", async () => {
+    vi.mocked(verifyAuthentication).mockResolvedValue({
+      verification: { verified: false },
+      passkey: { userId: "user-1" },
+    } as never);
+    const res = await POST(makeRequest({ "x-client-type": "native" }));
+    expect(res.status).toBe(401);
+    expect(prisma.apiToken.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/passkey/login-verify/route.ts
+++ b/src/app/api/auth/passkey/login-verify/route.ts
@@ -8,6 +8,7 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { NextRequest } from "next/server";
 import { apiHandler } from "@/lib/api-handler";
 import { annotate } from "@/lib/logging/context";
+import { issueApiToken, isNativeClientRequest } from "@/lib/auth/issue-token";
 
 export const POST = apiHandler(async (request: NextRequest) => {
   await ensureDbCompatibility();
@@ -58,6 +59,27 @@ export const POST = apiHandler(async (request: NextRequest) => {
   });
 
   annotate({ action: { name: "auth.login.passkey" } });
+
+  if (isNativeClientRequest(request.headers)) {
+    const issued = await issueApiToken({
+      userId: user.id,
+      name: `iOS auto-login ${new Date().toISOString()}`,
+      permissions: ["*"],
+      expiresInDays: 90,
+    });
+    await auditLog("auth.token.autoissue.native", {
+      userId: user.id,
+      ipAddress: ip,
+      details: { tokenId: issued.tokenId, source: "login.passkey" },
+    });
+    annotate({ action: { name: "auth.token.autoissue.native" } });
+
+    return apiSuccess({
+      user: { id: user.id, username: user.username },
+      token: issued.token,
+      tokenExpiresAt: issued.expiresAt.toISOString(),
+    });
+  }
 
   return apiSuccess({
     user: { id: user.id, username: user.username },

--- a/src/app/api/auth/profile/route.ts
+++ b/src/app/api/auth/profile/route.ts
@@ -1,62 +1,30 @@
-import { prisma } from "@/lib/db";
-import { profileSchema } from "@/lib/validations/auth";
-import { auditLog } from "@/lib/auth/audit";
 import { apiSuccess, apiError, getClientIp, safeJson } from "@/lib/api-response";
 import { NextRequest } from "next/server";
 import { apiHandler, requireAuth } from "@/lib/api-handler";
 import { annotate } from "@/lib/logging/context";
+import { applyProfileUpdate } from "@/lib/auth/profile-update";
 
 export const PUT = apiHandler(async (request: NextRequest) => {
   const { user } = await requireAuth();
 
   const { data: body, error: jsonError } = await safeJson(request);
-
   if (jsonError) return jsonError;
-  const parsed = profileSchema.safeParse(body);
 
-  if (!parsed.success) {
-    return apiError(parsed.error.issues[0].message, 422);
+  const result = await applyProfileUpdate(user.id, body, getClientIp(request));
+  if (!result.ok) {
+    return apiError(result.message, result.status);
   }
-
-  const data = parsed.data;
-  const normalizedEmail = data.email ? data.email.trim().toLowerCase() : null;
-
-  if (data.email !== undefined && normalizedEmail) {
-    const existingUser = await prisma.user.findUnique({
-      where: { email: normalizedEmail },
-      select: { id: true },
-    });
-
-    if (existingUser && existingUser.id !== user.id) {
-      return apiError("Email already in use", 409);
-    }
-  }
-
-  const updatedUser = await prisma.user.update({
-    where: { id: user.id },
-    data: {
-      ...(data.email !== undefined ? { email: normalizedEmail } : {}),
-      heightCm: data.heightCm ?? null,
-      dateOfBirth: data.dateOfBirth ? new Date(data.dateOfBirth) : null,
-      ...(data.gender !== undefined ? { gender: data.gender } : {}),
-    },
-  });
-
-  await auditLog("profile.update", {
-    userId: updatedUser.id,
-    ipAddress: getClientIp(request),
-  });
 
   annotate({ action: { name: "auth.profile.update" } });
 
   return apiSuccess({
-    id: updatedUser.id,
-    username: updatedUser.username,
-    email: updatedUser.email,
-    role: updatedUser.role,
-    heightCm: updatedUser.heightCm,
-    dateOfBirth: updatedUser.dateOfBirth,
-    gender: updatedUser.gender,
-    timezone: updatedUser.timezone,
+    id: result.user.id,
+    username: result.user.username,
+    email: result.user.email,
+    role: result.user.role,
+    heightCm: result.user.heightCm,
+    dateOfBirth: result.user.dateOfBirth,
+    gender: result.user.gender,
+    timezone: result.user.timezone,
   });
 });

--- a/src/app/api/dashboard/summary/__tests__/route.test.ts
+++ b/src/app/api/dashboard/summary/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    measurement: { findMany: vi.fn() },
+    medicationIntakeEvent: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({
+  emitIfSampled: vi.fn(),
+}));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: {
+    id: "user-1",
+    username: "marc",
+    role: "USER" as const,
+    displayName: null,
+  },
+};
+
+// `apiHandler` always reads `request.url` — even when the inner handler
+// ignores it — so we hand it a NextRequest and bypass the inner-handler
+// arity check via a cast.
+const callGet = GET as unknown as (req: NextRequest) => Promise<Response>;
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/dashboard/summary");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.measurement.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([] as never);
+});
+
+describe("GET /api/dashboard/summary", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the aggregated payload with empty data", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        greeting: { salutation: string; date: string };
+        streak: { currentDays: number; longest: number; label: string };
+        compliance: { scheduledToday: number; takenToday: number };
+        metrics: Array<{ id: string; kind: string; sparkline: number[] }>;
+      };
+    };
+    expect(body.data.greeting.salutation).toBe("Hi, marc");
+    expect(body.data.streak.currentDays).toBe(0);
+    expect(body.data.compliance.scheduledToday).toBe(0);
+    expect(body.data.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "weight" }),
+        expect.objectContaining({ id: "bp" }),
+        expect.objectContaining({ id: "pulse" }),
+      ]),
+    );
+  });
+
+  it("computes intake compliance for today", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.medicationIntakeEvent.findMany).mockImplementation(((
+      args: unknown,
+    ) => {
+      const a = args as { where: { OR?: unknown } };
+      if (!a.where.OR) {
+        return Promise.resolve([
+          { id: "e1", takenAt: new Date(), skipped: false },
+          { id: "e2", takenAt: null, skipped: false },
+        ]) as never;
+      }
+      return Promise.resolve([]) as never;
+    }) as never);
+    const res = await callGet(makeReq());
+    const body = (await res.json()) as {
+      data: { compliance: { scheduledToday: number; takenToday: number } };
+    };
+    expect(body.data.compliance.scheduledToday).toBe(2);
+    expect(body.data.compliance.takenToday).toBe(1);
+  });
+});

--- a/src/app/api/dashboard/summary/route.ts
+++ b/src/app/api/dashboard/summary/route.ts
@@ -1,0 +1,346 @@
+/**
+ * GET /api/dashboard/summary
+ *
+ * Aggregator endpoint for the iOS DashboardSummary view. Combines
+ * greeting, intake-day streaks, today's medication compliance, the
+ * highlighted insight, and per-metric latest+sparkline+trend.
+ *
+ * The shape is fixed for the iOS client and intentionally normalised —
+ * `kind` is iOS-friendly (camelCase), unlike the canonical Prisma enum
+ * (BLOOD_PRESSURE_SYS etc.).
+ */
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiSuccess } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { prisma } from "@/lib/db";
+import type { MeasurementType } from "@/generated/prisma/client";
+
+const SPARK_DAYS = 7;
+const STREAK_WINDOW_DAYS = 365;
+
+type MetricKind =
+  | "weight"
+  | "bloodPressure"
+  | "pulse"
+  | "bodyFat"
+  | "glucose"
+  | "sleep"
+  | "steps";
+
+interface MetricCard {
+  id: string;
+  kind: MetricKind;
+  title: string;
+  latestValue: number | null;
+  secondaryValue: number | null;
+  unit: string;
+  trend: "up" | "down" | "flat" | "unknown";
+  sparkline: number[];
+  updatedAt: string | null;
+}
+
+const METRIC_TITLES: Record<MetricKind, string> = {
+  weight: "Gewicht",
+  bloodPressure: "Blutdruck",
+  pulse: "Puls",
+  bodyFat: "Körperfett",
+  glucose: "Blutzucker",
+  sleep: "Schlaf",
+  steps: "Schritte",
+};
+
+const METRIC_UNITS: Record<MetricKind, string> = {
+  weight: "kg",
+  bloodPressure: "mmHg",
+  pulse: "bpm",
+  bodyFat: "%",
+  glucose: "mg/dL",
+  sleep: "h",
+  steps: "Schritte",
+};
+
+function trendOf(values: number[]): MetricCard["trend"] {
+  if (values.length < 2) return "unknown";
+  const first = values[0];
+  const last = values[values.length - 1];
+  const delta = last - first;
+  const epsilon = Math.max(1, Math.abs(first) * 0.01);
+  if (Math.abs(delta) < epsilon) return "flat";
+  return delta > 0 ? "up" : "down";
+}
+
+function startOfDayBerlin(date: Date): Date {
+  // Compute midnight in Europe/Berlin → UTC ms.
+  const berlin = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Berlin",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const y = berlin.find((p) => p.type === "year")?.value ?? "1970";
+  const m = berlin.find((p) => p.type === "month")?.value ?? "01";
+  const d = berlin.find((p) => p.type === "day")?.value ?? "01";
+  return new Date(`${y}-${m}-${d}T00:00:00.000Z`);
+}
+
+function berlinDayKey(date: Date): string {
+  return new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Europe/Berlin",
+  }).format(date);
+}
+
+interface StreakInfo {
+  currentDays: number;
+  longest: number;
+}
+
+/** Compute the current logging-day streak (days where any measurement or
+ *  intake event was recorded, in Berlin time) plus the longest streak in
+ *  the last `STREAK_WINDOW_DAYS` days. */
+function computeStreak(activityDays: Set<string>): StreakInfo {
+  if (activityDays.size === 0) return { currentDays: 0, longest: 0 };
+
+  const sorted = [...activityDays].sort();
+  let longest = 1;
+  let run = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = new Date(`${sorted[i - 1]}T00:00:00.000Z`).getTime();
+    const cur = new Date(`${sorted[i]}T00:00:00.000Z`).getTime();
+    if (cur - prev === 86_400_000) {
+      run += 1;
+      longest = Math.max(longest, run);
+    } else {
+      run = 1;
+    }
+  }
+
+  // Current streak: walk back from today (Berlin).
+  const todayKey = berlinDayKey(new Date());
+  let currentDays = 0;
+  let cursor = new Date(`${todayKey}T00:00:00.000Z`);
+  // Allow yesterday's last day to count if today not yet logged.
+  if (!activityDays.has(berlinDayKey(cursor))) {
+    cursor = new Date(cursor.getTime() - 86_400_000);
+  }
+  while (activityDays.has(berlinDayKey(cursor))) {
+    currentDays += 1;
+    cursor = new Date(cursor.getTime() - 86_400_000);
+  }
+
+  return { currentDays, longest };
+}
+
+export const GET = apiHandler(async () => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "dashboard.summary" } });
+
+  const now = new Date();
+  const sevenDaysAgo = new Date(now.getTime() - SPARK_DAYS * 86_400_000);
+  const streakWindowStart = new Date(
+    now.getTime() - STREAK_WINDOW_DAYS * 86_400_000,
+  );
+  const todayStart = startOfDayBerlin(now);
+  const todayEnd = new Date(todayStart.getTime() + 86_400_000);
+
+  const measurementTypes: MeasurementType[] = [
+    "WEIGHT",
+    "BLOOD_PRESSURE_SYS",
+    "BLOOD_PRESSURE_DIA",
+    "PULSE",
+    "BODY_FAT",
+    "BLOOD_GLUCOSE",
+    "SLEEP_DURATION",
+    "ACTIVITY_STEPS",
+  ];
+
+  const [recentMeasurements, todaysIntakes, streakActivity] =
+    await Promise.all([
+      prisma.measurement.findMany({
+        where: {
+          userId: user.id,
+          type: { in: measurementTypes },
+          measuredAt: { gte: sevenDaysAgo },
+        },
+        orderBy: { measuredAt: "asc" },
+        select: { type: true, value: true, measuredAt: true },
+      }),
+      prisma.medicationIntakeEvent.findMany({
+        where: {
+          userId: user.id,
+          scheduledFor: { gte: todayStart, lt: todayEnd },
+        },
+        select: { id: true, takenAt: true, skipped: true },
+      }),
+      prisma.medicationIntakeEvent.findMany({
+        where: {
+          userId: user.id,
+          scheduledFor: { gte: streakWindowStart },
+          OR: [{ takenAt: { not: null } }, { skipped: true }],
+        },
+        select: { takenAt: true, scheduledFor: true },
+      }),
+    ]);
+
+  const activityDays = new Set<string>();
+  for (const m of recentMeasurements) activityDays.add(berlinDayKey(m.measuredAt));
+  // Pull a wider measurement window for the streak so it isn't capped by
+  // SPARK_DAYS — but only if the user has any data at all.
+  if (recentMeasurements.length > 0) {
+    const wider = await prisma.measurement.findMany({
+      where: {
+        userId: user.id,
+        measuredAt: { gte: streakWindowStart },
+      },
+      select: { measuredAt: true },
+    });
+    for (const m of wider) activityDays.add(berlinDayKey(m.measuredAt));
+  }
+  for (const e of streakActivity) {
+    activityDays.add(berlinDayKey(e.takenAt ?? e.scheduledFor));
+  }
+
+  const streak = computeStreak(activityDays);
+
+  // Per-type latest + sparkline.
+  const byType = new Map<MeasurementType, { value: number; at: Date }[]>();
+  for (const m of recentMeasurements) {
+    const list = byType.get(m.type) ?? [];
+    list.push({ value: m.value, at: m.measuredAt });
+    byType.set(m.type, list);
+  }
+
+  function latestOf(type: MeasurementType): { value: number; at: Date } | null {
+    const list = byType.get(type);
+    if (!list || list.length === 0) return null;
+    return list[list.length - 1];
+  }
+
+  function sparkOf(type: MeasurementType): number[] {
+    const list = byType.get(type);
+    if (!list) return [];
+    return list.map((p) => p.value);
+  }
+
+  const metrics: MetricCard[] = [];
+
+  // Weight
+  {
+    const latest = latestOf("WEIGHT");
+    const spark = sparkOf("WEIGHT");
+    metrics.push({
+      id: "weight",
+      kind: "weight",
+      title: METRIC_TITLES.weight,
+      latestValue: latest?.value ?? null,
+      secondaryValue: null,
+      unit: METRIC_UNITS.weight,
+      trend: trendOf(spark),
+      sparkline: spark,
+      updatedAt: latest?.at.toISOString() ?? null,
+    });
+  }
+
+  // Blood pressure (paired sys/dia)
+  {
+    const sysList = byType.get("BLOOD_PRESSURE_SYS") ?? [];
+    const diaList = byType.get("BLOOD_PRESSURE_DIA") ?? [];
+    const latestSys = sysList[sysList.length - 1] ?? null;
+    const latestDia = diaList[diaList.length - 1] ?? null;
+    metrics.push({
+      id: "bp",
+      kind: "bloodPressure",
+      title: METRIC_TITLES.bloodPressure,
+      latestValue: latestSys?.value ?? null,
+      secondaryValue: latestDia?.value ?? null,
+      unit: METRIC_UNITS.bloodPressure,
+      trend: trendOf(sysList.map((p) => p.value)),
+      sparkline: sysList.map((p) => p.value),
+      updatedAt:
+        latestSys?.at.toISOString() ?? latestDia?.at.toISOString() ?? null,
+    });
+  }
+
+  // Pulse
+  {
+    const latest = latestOf("PULSE");
+    const spark = sparkOf("PULSE");
+    metrics.push({
+      id: "pulse",
+      kind: "pulse",
+      title: METRIC_TITLES.pulse,
+      latestValue: latest?.value ?? null,
+      secondaryValue: null,
+      unit: METRIC_UNITS.pulse,
+      trend: trendOf(spark),
+      sparkline: spark,
+      updatedAt: latest?.at.toISOString() ?? null,
+    });
+  }
+
+  // Body fat
+  {
+    const latest = latestOf("BODY_FAT");
+    const spark = sparkOf("BODY_FAT");
+    if (latest) {
+      metrics.push({
+        id: "bodyFat",
+        kind: "bodyFat",
+        title: METRIC_TITLES.bodyFat,
+        latestValue: latest.value,
+        secondaryValue: null,
+        unit: METRIC_UNITS.bodyFat,
+        trend: trendOf(spark),
+        sparkline: spark,
+        updatedAt: latest.at.toISOString(),
+      });
+    }
+  }
+
+  // Glucose / sleep / steps — only if data is present.
+  for (const [type, kind] of [
+    ["BLOOD_GLUCOSE", "glucose"],
+    ["SLEEP_DURATION", "sleep"],
+    ["ACTIVITY_STEPS", "steps"],
+  ] as const) {
+    const latest = latestOf(type);
+    if (!latest) continue;
+    const spark = sparkOf(type);
+    metrics.push({
+      id: kind,
+      kind,
+      title: METRIC_TITLES[kind],
+      latestValue: latest.value,
+      secondaryValue: null,
+      unit: METRIC_UNITS[kind],
+      trend: trendOf(spark),
+      sparkline: spark,
+      updatedAt: latest.at.toISOString(),
+    });
+  }
+
+  const scheduledToday = todaysIntakes.length;
+  const takenToday = todaysIntakes.filter(
+    (e) => e.takenAt !== null && !e.skipped,
+  ).length;
+
+  const greetingName = user.displayName ?? user.username;
+
+  return apiSuccess({
+    greeting: {
+      salutation: `Hi, ${greetingName}`,
+      date: now.toISOString(),
+    },
+    streak: {
+      currentDays: streak.currentDays,
+      longest: streak.longest,
+      label: "Tage in Folge",
+    },
+    compliance: {
+      scheduledToday,
+      takenToday,
+    },
+    highlightInsight: null,
+    metrics,
+    lastUpdated: now.toISOString(),
+  });
+});

--- a/src/app/api/devices/__tests__/route.test.ts
+++ b/src/app/api/devices/__tests__/route.test.ts
@@ -86,11 +86,26 @@ describe("POST /api/devices", () => {
     expect(prisma.device.update).not.toHaveBeenCalled();
   });
 
-  it("upserts when token already exists (transfers ownership)", async () => {
+  it("rejects cross-user re-registration with 409", async () => {
     vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
     vi.mocked(prisma.device.findUnique).mockResolvedValue({
       id: "dev-1",
       userId: "other-user",
+      token: "abcd1234efgh5678",
+    } as never);
+    const res = await POST(
+      req({ token: "abcd1234efgh5678", bundleId: "io.healthlog.app" }),
+    );
+    expect(res.status).toBe(409);
+    expect(prisma.device.update).not.toHaveBeenCalled();
+    expect(prisma.device.create).not.toHaveBeenCalled();
+  });
+
+  it("updates in place when same user re-registers their own token", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.device.findUnique).mockResolvedValue({
+      id: "dev-1",
+      userId: "user-1",
       token: "abcd1234efgh5678",
     } as never);
     const res = await POST(

--- a/src/app/api/devices/__tests__/route.test.ts
+++ b/src/app/api/devices/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    device: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { POST } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+function req(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/devices", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.device.findUnique).mockResolvedValue(null);
+  vi.mocked(prisma.device.create).mockResolvedValue({ id: "dev-1" } as never);
+  vi.mocked(prisma.device.update).mockResolvedValue({ id: "dev-1" } as never);
+});
+
+describe("POST /api/devices", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await POST(
+      req({
+        token: "abcd1234efgh5678",
+        bundleId: "io.healthlog.app",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 for missing token", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await POST(req({ bundleId: "io.healthlog.app" }));
+    expect(res.status).toBe(422);
+  });
+
+  it("creates a new device row when token is unknown", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await POST(
+      req({
+        token: "abcd1234efgh5678",
+        bundleId: "io.healthlog.app",
+        locale: "de-DE",
+        appVersion: "1.0.0",
+        model: "iPhone15,2",
+      }),
+    );
+    expect(res.status).toBe(201);
+    expect(prisma.device.create).toHaveBeenCalledTimes(1);
+    expect(prisma.device.update).not.toHaveBeenCalled();
+  });
+
+  it("upserts when token already exists (transfers ownership)", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.device.findUnique).mockResolvedValue({
+      id: "dev-1",
+      userId: "other-user",
+      token: "abcd1234efgh5678",
+    } as never);
+    const res = await POST(
+      req({ token: "abcd1234efgh5678", bundleId: "io.healthlog.app" }),
+    );
+    expect(res.status).toBe(201);
+    expect(prisma.device.update).toHaveBeenCalledTimes(1);
+    expect(prisma.device.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/devices/route.ts
+++ b/src/app/api/devices/route.ts
@@ -43,10 +43,20 @@ export const POST = apiHandler(async (request: NextRequest) => {
   const existing = await prisma.device.findUnique({ where: { token } });
   let id: string;
   if (existing) {
+    // Cross-user-hijack guard: a device-token belongs to exactly one user.
+    // Re-registering the same token under a different account is rejected
+    // — APNs tokens aren't a secret, so trusting the wire input would let
+    // anyone who learns/guesses a token redirect another user's pushes.
+    if (existing.userId !== user.id) {
+      await auditLog("device.register.denied", {
+        userId: user.id,
+        details: { reason: "token_owned_by_other_user", deviceId: existing.id },
+      });
+      return apiError("Device token already registered to another account", 409);
+    }
     const updated = await prisma.device.update({
       where: { token },
       data: {
-        userId: user.id,
         platform: "ios",
         bundleId,
         locale: locale ?? null,

--- a/src/app/api/devices/route.ts
+++ b/src/app/api/devices/route.ts
@@ -1,0 +1,86 @@
+/**
+ * POST /api/devices
+ *
+ * APNs device registration. Native clients call this on login and on
+ * APNs token rotation. We upsert by `token`; sending the same token on a
+ * different account simply transfers ownership.
+ *
+ * No APNs send-side logic lives here — that ships in Phase 8.
+ */
+import { NextRequest } from "next/server";
+import { z } from "zod/v4";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiError, apiSuccess, safeJson } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { prisma } from "@/lib/db";
+import { auditLog } from "@/lib/auth/audit";
+
+const deviceSchema = z.object({
+  token: z
+    .string()
+    .min(8)
+    .max(512)
+    .regex(/^[A-Za-z0-9+/=._:-]+$/, "Invalid token format"),
+  bundleId: z.string().min(1).max(128),
+  locale: z.string().min(2).max(16).optional(),
+  appVersion: z.string().min(1).max(32).optional(),
+  model: z.string().min(1).max(64).optional(),
+});
+
+export const POST = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const { data: body, error } = await safeJson(request);
+  if (error) return error;
+
+  const parsed = deviceSchema.safeParse(body);
+  if (!parsed.success) {
+    return apiError(parsed.error.issues[0].message, 422);
+  }
+
+  const { token, bundleId, locale, appVersion, model } = parsed.data;
+
+  const existing = await prisma.device.findUnique({ where: { token } });
+  let id: string;
+  if (existing) {
+    const updated = await prisma.device.update({
+      where: { token },
+      data: {
+        userId: user.id,
+        platform: "ios",
+        bundleId,
+        locale: locale ?? null,
+        appVersion: appVersion ?? null,
+        model: model ?? null,
+        lastSeen: new Date(),
+      },
+      select: { id: true },
+    });
+    id = updated.id;
+  } else {
+    const created = await prisma.device.create({
+      data: {
+        userId: user.id,
+        platform: "ios",
+        token,
+        bundleId,
+        locale: locale ?? null,
+        appVersion: appVersion ?? null,
+        model: model ?? null,
+      },
+      select: { id: true },
+    });
+    id = created.id;
+  }
+
+  await auditLog("devices.register", {
+    userId: user.id,
+    details: { deviceId: id, bundleId, model: model ?? null },
+  });
+
+  annotate({
+    action: { name: "devices.register", entity_type: "device", entity_id: id },
+  });
+
+  return apiSuccess({ id }, 201);
+});

--- a/src/app/api/doctor-report/__tests__/pdf-route.test.ts
+++ b/src/app/api/doctor-report/__tests__/pdf-route.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// --- Mocks must come before importing the route. ---
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    measurement: { findMany: vi.fn() },
+    medication: { findMany: vi.fn() },
+    medicationIntakeEvent: { findMany: vi.fn() },
+    moodEntry: { findMany: vi.fn() },
+    user: { findUnique: vi.fn() },
+    auditLog: { create: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/geo", () => ({
+  lookupIpLocation: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/effective-range", () => ({
+  getEffectiveRange: vi.fn(() => ({ range: null })),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({
+  emitIfSampled: vi.fn(),
+}));
+
+import { POST } from "../pdf/route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { auditLog } from "@/lib/auth/audit";
+
+function makeRequest(
+  body?: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): NextRequest {
+  const baseHeaders: Record<string, string> = {
+    "content-type": "application/json",
+    ...headers,
+  };
+  return new NextRequest("http://localhost/api/doctor-report/pdf", {
+    method: "POST",
+    headers: baseHeaders,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3600_000) },
+  user: { id: "user-1", role: "USER" as const },
+};
+
+function setEmptyDataMocks() {
+  vi.mocked(prisma.measurement.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medication.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue(
+    [] as never,
+  );
+  vi.mocked(prisma.moodEntry.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    username: "marc",
+    dateOfBirth: null,
+    gender: null,
+    heightCm: null,
+    glucoseUnit: null,
+    thresholdsJson: null,
+  } as never);
+}
+
+describe("POST /api/doctor-report/pdf", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ days: 90 }));
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("Not authenticated");
+  });
+
+  it("returns 429 when rate limit exceeded", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 3600_000,
+    });
+
+    const res = await POST(makeRequest({ days: 90 }));
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toMatch(/Maximum/);
+  });
+
+  it("returns 200 application/pdf with PDF bytes on happy path", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      resetAt: Date.now() + 3600_000,
+    });
+    vi.mocked(auditLog).mockResolvedValue(undefined as never);
+    setEmptyDataMocks();
+
+    const res = await POST(
+      makeRequest({ days: 30, locale: "de" }, { "accept-language": "de-DE" }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const disposition = res.headers.get("content-disposition") ?? "";
+    expect(disposition).toMatch(/attachment;\s*filename="healthlog-report-/);
+    expect(disposition).toMatch(/\.pdf"/);
+
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.byteLength).toBeGreaterThan(1024);
+    expect(buf.slice(0, 5).toString("utf8")).toBe("%PDF-");
+
+    expect(auditLog).toHaveBeenCalledWith(
+      "doctor-report.pdf.generate",
+      expect.objectContaining({
+        userId: "user-1",
+        details: expect.objectContaining({ days: 30, locale: "de" }),
+      }),
+    );
+  });
+
+  it("falls back to default days=90 when body omits it", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      resetAt: Date.now() + 3600_000,
+    });
+    vi.mocked(auditLog).mockResolvedValue(undefined as never);
+    setEmptyDataMocks();
+
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(200);
+    expect(auditLog).toHaveBeenCalledWith(
+      "doctor-report.pdf.generate",
+      expect.objectContaining({
+        details: expect.objectContaining({ days: 90 }),
+      }),
+    );
+  });
+
+  it("uses Accept-Language to pick the locale when body omits it", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      allowed: true,
+      remaining: 9,
+      resetAt: Date.now() + 3600_000,
+    });
+    vi.mocked(auditLog).mockResolvedValue(undefined as never);
+    setEmptyDataMocks();
+
+    const res = await POST(
+      makeRequest({ days: 7 }, { "accept-language": "en-US,en;q=0.9" }),
+    );
+    expect(res.status).toBe(200);
+    expect(auditLog).toHaveBeenCalledWith(
+      "doctor-report.pdf.generate",
+      expect.objectContaining({
+        details: expect.objectContaining({ locale: "en" }),
+      }),
+    );
+  });
+});

--- a/src/app/api/doctor-report/pdf/route.ts
+++ b/src/app/api/doctor-report/pdf/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { annotate } from "@/lib/logging/context";
+import { auditLog } from "@/lib/auth/audit";
+import { apiError, getClientIp } from "@/lib/api-response";
+import { checkRateLimit } from "@/lib/rate-limit";
+import {
+  collectDoctorReportData,
+  normaliseDays,
+} from "@/lib/doctor-report-data";
+import { renderDoctorReportPdfBytes } from "@/lib/doctor-report-pdf-core";
+import { getServerTranslator } from "@/lib/i18n/server-translator";
+import { parseLocaleFromAcceptLanguage } from "@/lib/format-locale";
+import { locales, type Locale } from "@/lib/i18n/config";
+
+/**
+ * Server-rendered PDF doctor report.
+ *
+ * Mirrors `/api/doctor-report` (which returns JSON for client-side rendering)
+ * but produces the finished PDF bytes server-side. Useful on iOS / Safari where
+ * the client-side jsPDF download UX is unreliable.
+ *
+ * Auth, rate-limit (10/h), and audit-log policy match the JSON endpoint.
+ */
+export const POST = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "doctor-report.pdf.generate" } });
+
+  const rl = await checkRateLimit(
+    `doctor-report:${user.id}`,
+    10,
+    60 * 60 * 1000,
+  );
+  if (!rl.allowed) {
+    return apiError("Maximum 10 reports per hour", 429);
+  }
+
+  // Body is optional — JSON is allowed but not required.
+  const body = await readOptionalJsonBody(request);
+  const days = normaliseDays(body?.days);
+  const locale = resolveLocale(
+    body?.locale,
+    request.headers.get("accept-language"),
+  );
+
+  const data = await collectDoctorReportData(user.id, days);
+
+  const { t } = getServerTranslator(locale);
+  const pdfBytes = renderDoctorReportPdfBytes(data, { t, locale });
+
+  await auditLog("doctor-report.pdf.generate", {
+    userId: user.id,
+    ipAddress: getClientIp(request),
+    details: { days, locale },
+  });
+
+  annotate({ meta: { report_days: days, locale, bytes: pdfBytes.byteLength } });
+
+  const filename = `healthlog-report-${new Date().toISOString().slice(0, 10)}.pdf`;
+  // NextResponse accepts a BodyInit; copy to a fresh ArrayBuffer to avoid
+  // SharedArrayBuffer typing surprises with Uint8Array.
+  const buffer = pdfBytes.slice().buffer;
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Length": String(pdfBytes.byteLength),
+      "Cache-Control": "no-store",
+    },
+  });
+});
+
+interface PdfRequestBody {
+  days?: unknown;
+  locale?: unknown;
+}
+
+/**
+ * Best-effort JSON body parse. Returns `null` if the request had no body or
+ * a non-JSON content type — both are acceptable for this endpoint.
+ */
+async function readOptionalJsonBody(
+  request: NextRequest,
+): Promise<PdfRequestBody | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) return null;
+  try {
+    return (await request.json()) as PdfRequestBody;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the active locale: explicit body override wins, then a parsed
+ * `Accept-Language`, then a hard fallback to German (the primary HealthLog
+ * locale for the medical context).
+ */
+function resolveLocale(
+  bodyLocale: unknown,
+  acceptLanguage: string | null,
+): Locale {
+  if (
+    typeof bodyLocale === "string" &&
+    (locales as readonly string[]).includes(bodyLocale)
+  ) {
+    return bodyLocale as Locale;
+  }
+  if (!acceptLanguage) return "de";
+  // parseLocaleFromAcceptLanguage returns "de" for de-* headers, otherwise
+  // "en" — matching the broader app's i18n behaviour for present headers.
+  return parseLocaleFromAcceptLanguage(acceptLanguage);
+}

--- a/src/app/api/doctor-report/route.ts
+++ b/src/app/api/doctor-report/route.ts
@@ -1,16 +1,18 @@
-import { prisma } from "@/lib/db";
 import { apiHandler, requireAuth } from "@/lib/api-handler";
 import { annotate } from "@/lib/logging/context";
 import { auditLog } from "@/lib/auth/audit";
-import { apiSuccess, apiError, getClientIp, safeJson } from "@/lib/api-response";
+import {
+  apiSuccess,
+  apiError,
+  getClientIp,
+  safeJson,
+} from "@/lib/api-response";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { NextRequest } from "next/server";
 import {
-  getEffectiveRange,
-  type ThresholdOverridesJson,
-} from "@/lib/analytics/effective-range";
-import { resolveGlucoseUnit, thresholdMetricForContext } from "@/lib/glucose";
-import type { GlucoseContext } from "@/generated/prisma/client";
+  collectDoctorReportData,
+  normaliseDays,
+} from "@/lib/doctor-report-data";
 
 /**
  * Collect data for doctor report PDF generation (client-side).
@@ -20,203 +22,28 @@ export const POST = apiHandler(async (request: NextRequest) => {
   const { user } = await requireAuth();
   annotate({ action: { name: "doctor-report.generate" } });
 
-  const rl = await checkRateLimit(`doctor-report:${user.id}`, 10, 60 * 60 * 1000);
+  const rl = await checkRateLimit(
+    `doctor-report:${user.id}`,
+    10,
+    60 * 60 * 1000,
+  );
   if (!rl.allowed) {
     return apiError("Maximum 10 reports per hour", 429);
   }
 
   const { data: body, error: jsonError } = await safeJson(request);
-
   if (jsonError) return jsonError;
-  const rawDays = (body as Record<string, unknown>)?.days;
-  const days =
-    typeof rawDays === "number" && Number.isInteger(rawDays) && rawDays >= 1 && rawDays <= 365
-      ? rawDays
-      : 90;
-  const since = new Date();
-  since.setDate(since.getDate() - days);
 
-  const userId = user.id;
-
-  const [measurements, medications, intakeEvents, moodEntries, userProfile] =
-    await Promise.all([
-      prisma.measurement.findMany({
-        where: { userId, measuredAt: { gte: since } },
-        orderBy: { measuredAt: "asc" },
-      }),
-      prisma.medication.findMany({
-        where: { userId, active: true },
-        include: { schedules: true },
-      }),
-      prisma.medicationIntakeEvent.findMany({
-        where: { userId, scheduledFor: { gte: since } },
-        include: { medication: { select: { name: true } } },
-        orderBy: { scheduledFor: "asc" },
-      }),
-      prisma.moodEntry.findMany({
-        where: { userId, moodLoggedAt: { gte: since } },
-        orderBy: { moodLoggedAt: "asc" },
-      }),
-      prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          username: true,
-          dateOfBirth: true,
-          gender: true,
-          heightCm: true,
-          glucoseUnit: true,
-          thresholdsJson: true,
-        },
-      }),
-    ]);
-
-  // Group measurements by type
-  const byType: Record<
-    string,
-    Array<{ value: number; measuredAt: string }>
-  > = {};
-  for (const m of measurements) {
-    if (!byType[m.type]) byType[m.type] = [];
-    byType[m.type].push({
-      value: m.value,
-      measuredAt: m.measuredAt.toISOString(),
-    });
-  }
-
-  // Calculate stats per type
-  const stats: Record<
-    string,
-    { avg: number; min: number; max: number; count: number; latest: number }
-  > = {};
-  for (const [type, entries] of Object.entries(byType)) {
-    const values = entries.map((e) => e.value);
-    stats[type] = {
-      avg: values.reduce((a, b) => a + b, 0) / values.length,
-      min: Math.min(...values),
-      max: Math.max(...values),
-      count: values.length,
-      latest: values[values.length - 1],
-    };
-  }
-
-  // Medication compliance
-  const complianceByMed: Record<
-    string,
-    { total: number; taken: number; skipped: number; missed: number }
-  > = {};
-  for (const event of intakeEvents) {
-    const name = event.medication.name;
-    if (!complianceByMed[name]) {
-      complianceByMed[name] = { total: 0, taken: 0, skipped: 0, missed: 0 };
-    }
-    complianceByMed[name].total++;
-    if (event.takenAt) {
-      complianceByMed[name].taken++;
-    } else if (event.skipped) {
-      complianceByMed[name].skipped++;
-    } else {
-      complianceByMed[name].missed++;
-    }
-  }
-
-  // Mood summary
-  const moodScores = moodEntries.map((e) => e.score);
-  const moodSummary =
-    moodScores.length > 0
-      ? {
-          avg: moodScores.reduce((a, b) => a + b, 0) / moodScores.length,
-          min: Math.min(...moodScores),
-          max: Math.max(...moodScores),
-          count: moodScores.length,
-          distribution: {
-            1: moodScores.filter((s) => s === 1).length,
-            2: moodScores.filter((s) => s === 2).length,
-            3: moodScores.filter((s) => s === 3).length,
-            4: moodScores.filter((s) => s === 4).length,
-            5: moodScores.filter((s) => s === 5).length,
-          },
-        }
-      : null;
-
-  // BMI
-  const weightStats = stats.WEIGHT;
-  const bmi =
-    weightStats && userProfile?.heightCm
-      ? weightStats.latest / (userProfile.heightCm / 100) ** 2
-      : null;
+  const days = normaliseDays((body as Record<string, unknown>)?.days);
+  const data = await collectDoctorReportData(user.id, days);
 
   await auditLog("doctor-report.generate", {
-    userId,
+    userId: user.id,
     ipAddress: getClientIp(request),
     details: { days },
   });
 
   annotate({ meta: { report_days: days } });
 
-  // Per-context glucose stats (canonical mg/dL) and effective ranges.
-  const glucoseContexts: GlucoseContext[] = [
-    "FASTING",
-    "POSTPRANDIAL",
-    "RANDOM",
-    "BEDTIME",
-  ];
-  const glucoseStats: Record<
-    string,
-    { avg: number; min: number; max: number; count: number; latest: number }
-  > = {};
-  const glucoseRanges: Record<string, { min: number; max: number }> = {};
-  const glucoseRows = measurements.filter((m) => m.type === "BLOOD_GLUCOSE");
-  const overrides = (userProfile?.thresholdsJson ?? null) as ThresholdOverridesJson | null;
-  const profileForRange = {
-    heightCm: userProfile?.heightCm ?? null,
-    dateOfBirth: userProfile?.dateOfBirth ?? null,
-    gender: userProfile?.gender ?? null,
-  };
-  for (const ctx of glucoseContexts) {
-    const rows = glucoseRows.filter((m) => m.glucoseContext === ctx);
-    if (rows.length === 0) continue;
-    const values = rows.map((r) => r.value);
-    glucoseStats[ctx] = {
-      avg: values.reduce((a, b) => a + b, 0) / values.length,
-      min: Math.min(...values),
-      max: Math.max(...values),
-      count: values.length,
-      latest: values[values.length - 1],
-    };
-    const eff = getEffectiveRange(
-      thresholdMetricForContext(ctx),
-      profileForRange,
-      overrides,
-    );
-    if (eff.range) {
-      glucoseRanges[ctx] = { min: eff.range.greenMin, max: eff.range.greenMax };
-    }
-  }
-
-  return apiSuccess({
-    period: { days, since: since.toISOString() },
-    patient: {
-      username: userProfile?.username ?? null,
-      dateOfBirth: userProfile?.dateOfBirth ?? null,
-      gender: userProfile?.gender ?? null,
-      heightCm: userProfile?.heightCm ?? null,
-    },
-    measurements: byType,
-    stats,
-    glucoseStats,
-    glucoseRanges,
-    glucoseUnit: resolveGlucoseUnit(userProfile?.glucoseUnit ?? null),
-    bmi: bmi ? Math.round(bmi * 10) / 10 : null,
-    compliance: complianceByMed,
-    medications: medications.map((m) => ({
-      name: m.name,
-      dose: m.dose,
-      schedules: m.schedules.map((s) => ({
-        windowStart: s.windowStart,
-        windowEnd: s.windowEnd,
-        label: s.label,
-      })),
-    })),
-    mood: moodSummary,
-  });
+  return apiSuccess(data);
 });

--- a/src/app/api/gamification/achievements/__tests__/ios-format.test.ts
+++ b/src/app/api/gamification/achievements/__tests__/ios-format.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    measurement: { findMany: vi.fn() },
+    medicationIntakeEvent: { findMany: vi.fn() },
+    medication: { findMany: vi.fn() },
+    passkey: { findMany: vi.fn() },
+    auditLog: { findMany: vi.fn() },
+    userAchievement: {
+      findMany: vi.fn(),
+      createMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: {
+    id: "user-1",
+    username: "marc",
+    role: "USER" as const,
+    createdAt: new Date("2026-03-01T00:00:00.000Z"),
+    heightCm: null,
+    locale: "en",
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.measurement.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medication.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.passkey.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.auditLog.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.userAchievement.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.userAchievement.createMany).mockResolvedValue({
+    count: 0,
+  } as never);
+});
+
+describe("GET /api/gamification/achievements?format=ios", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await GET(
+      new NextRequest(
+        "http://localhost/api/gamification/achievements?format=ios",
+      ),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns a flat iOS-shaped achievement array", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await GET(
+      new NextRequest(
+        "http://localhost/api/gamification/achievements?format=ios",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{
+        id: string;
+        key: string;
+        title: string;
+        description: string;
+        iconName: string;
+        unlocked: boolean;
+        unlockedAt: string | null;
+        progress: number;
+      }>;
+    };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBeGreaterThan(0);
+    const first = body.data[0];
+    expect(first.id).toEqual(expect.any(String));
+    expect(first.key).toEqual(expect.any(String));
+    expect(first.title).toEqual(expect.any(String));
+    expect(first.iconName).toEqual(expect.any(String));
+    expect(first.progress).toBeGreaterThanOrEqual(0);
+    expect(first.progress).toBeLessThanOrEqual(1);
+  });
+
+  it("falls back to the legacy wrapped shape when no format is given", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await GET(
+      new NextRequest("http://localhost/api/gamification/achievements"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { achievements: unknown[]; summary: unknown };
+    };
+    expect(body.data.achievements).toBeDefined();
+    expect(body.data.summary).toBeDefined();
+  });
+});

--- a/src/app/api/gamification/achievements/route.ts
+++ b/src/app/api/gamification/achievements/route.ts
@@ -15,6 +15,20 @@ import {
   classifyPulse,
 } from "@/lib/analytics/classifications";
 import { classifyIntakeTiming } from "@/lib/analytics/compliance";
+import { getServerTranslator } from "@/lib/i18n/server-translator";
+import { resolveServerLocale } from "@/lib/i18n/server-locale";
+import type { NextRequest } from "next/server";
+
+interface IosAchievement {
+  id: string;
+  key: string;
+  title: string;
+  description: string;
+  iconName: string;
+  unlocked: boolean;
+  unlockedAt: string | null;
+  progress: number;
+}
 
 export const dynamic = "force-dynamic";
 
@@ -431,9 +445,14 @@ function getCompliance80DaySeries(
   return toDaySeries(greenDays);
 }
 
-export const GET = apiHandler(async () => {
+export const GET = apiHandler(async (request: NextRequest) => {
   const { user } = await requireAuth();
-  annotate({ action: { name: "gamification.achievements" } });
+  const formatParam = request.nextUrl.searchParams.get("format");
+  const isIosFormat = formatParam === "ios";
+  annotate({
+    action: { name: "gamification.achievements" },
+    meta: { format: isIosFormat ? "ios" : "default" },
+  });
 
   const now = new Date();
   const userId = user.id;
@@ -740,6 +759,25 @@ export const GET = apiHandler(async () => {
       })),
       skipDuplicates: true,
     });
+  }
+
+  if (isIosFormat) {
+    const locale = await resolveServerLocale({
+      request,
+      userLocale: user.locale,
+    });
+    const t = getServerTranslator(locale);
+    const ios: IosAchievement[] = result.achievements.map((a) => ({
+      id: a.id,
+      key: a.id,
+      title: t.t(a.titleKey),
+      description: t.t(a.descriptionKey),
+      iconName: a.icon,
+      unlocked: a.unlocked,
+      unlockedAt: a.completedAt,
+      progress: Math.max(0, Math.min(1, a.progressPercent / 100)),
+    }));
+    return apiSuccess(ios);
   }
 
   return apiSuccess(result);

--- a/src/app/api/insights/cards/__tests__/route.test.ts
+++ b/src/app/api/insights/cards/__tests__/route.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    measurement: { findMany: vi.fn() },
+    medication: { findMany: vi.fn() },
+    medicationIntakeEvent: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.measurement.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medication.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    heightCm: null,
+    dateOfBirth: null,
+    aiProvider: null,
+  } as never);
+});
+
+const callGet = GET as unknown as (req: NextRequest) => Promise<Response>;
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/insights/cards");
+}
+
+describe("GET /api/insights/cards", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an empty array when no data is available", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data).toHaveLength(0);
+  });
+
+  it("emits cards when measurements trigger alerts", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    // Provide enough sys + dia measurements to trigger danger-level alert.
+    const now = new Date();
+    const measurements: Array<{
+      type: string;
+      value: number;
+      measuredAt: Date;
+    }> = [];
+    for (let i = 0; i < 10; i++) {
+      const at = new Date(now.getTime() - i * 86_400_000);
+      measurements.push({ type: "BLOOD_PRESSURE_SYS", value: 180, measuredAt: at });
+      measurements.push({ type: "BLOOD_PRESSURE_DIA", value: 110, measuredAt: at });
+    }
+    vi.mocked(prisma.measurement.findMany).mockResolvedValue(measurements as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      heightCm: null,
+      dateOfBirth: null,
+      aiProvider: "ANTHROPIC",
+    } as never);
+
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ severity: string; provider: string; title: string }>;
+    };
+    expect(body.data.length).toBeGreaterThan(0);
+    expect(body.data[0].provider).toBe("anthropic");
+    expect(body.data.some((c) => c.severity === "alert")).toBe(true);
+  });
+});

--- a/src/app/api/insights/cards/route.ts
+++ b/src/app/api/insights/cards/route.ts
@@ -133,31 +133,38 @@ export const GET = apiHandler(async () => {
     compliance7: number;
     compliance30: number;
   }> = [];
-  for (const med of medications) {
-    if (med.schedules.length === 0) continue;
-    const events = await prisma.medicationIntakeEvent.findMany({
+  // Single batched query — bucket by medicationId in JS (fix N+1).
+  const activeMeds = medications.filter((m) => m.schedules.length > 0);
+  if (activeMeds.length > 0) {
+    const allEvents = await prisma.medicationIntakeEvent.findMany({
       where: {
         userId: user.id,
-        medicationId: med.id,
+        medicationId: { in: activeMeds.map((m) => m.id) },
         scheduledFor: { gte: new Date(Date.now() - 30 * 86_400_000) },
       },
-      select: { takenAt: true, skipped: true, scheduledFor: true },
+      select: { medicationId: true, takenAt: true, skipped: true, scheduledFor: true },
     });
-    const takenLast7 = events.filter(
-      (e) =>
-        e.takenAt !== null &&
-        !e.skipped &&
-        e.scheduledFor.getTime() >= Date.now() - 7 * 86_400_000,
-    ).length;
-    const taken30 = events.filter((e) => e.takenAt !== null && !e.skipped).length;
-    const expected7 = med.schedules.length * 7;
-    const expected30 = med.schedules.length * 30;
-    medicationCompliance.push({
-      name: med.name,
-      compliance7: expected7 > 0 ? Math.round((takenLast7 / expected7) * 100) : 0,
-      compliance30:
-        expected30 > 0 ? Math.round((taken30 / expected30) * 100) : 0,
-    });
+    const eventsByMed = new Map<string, typeof allEvents>();
+    for (const e of allEvents) {
+      const arr = eventsByMed.get(e.medicationId) ?? [];
+      arr.push(e);
+      eventsByMed.set(e.medicationId, arr);
+    }
+    const cutoff7 = Date.now() - 7 * 86_400_000;
+    for (const med of activeMeds) {
+      const events = eventsByMed.get(med.id) ?? [];
+      const takenLast7 = events.filter(
+        (e) => e.takenAt !== null && !e.skipped && e.scheduledFor.getTime() >= cutoff7,
+      ).length;
+      const taken30 = events.filter((e) => e.takenAt !== null && !e.skipped).length;
+      const expected7 = med.schedules.length * 7;
+      const expected30 = med.schedules.length * 30;
+      medicationCompliance.push({
+        name: med.name,
+        compliance7: expected7 > 0 ? Math.round((takenLast7 / expected7) * 100) : 0,
+        compliance30: expected30 > 0 ? Math.round((taken30 / expected30) * 100) : 0,
+      });
+    }
   }
 
   const alerts = generateAlerts({

--- a/src/app/api/insights/cards/route.ts
+++ b/src/app/api/insights/cards/route.ts
@@ -1,0 +1,189 @@
+/**
+ * GET /api/insights/cards — iOS adapter over `/api/insights/comprehensive`.
+ *
+ * Reuses the same data sources (measurements, mood, intake events) and the
+ * shared `generateAlerts()` rule engine, then re-shapes each `HealthAlert`
+ * to the iOS Insight model (id, title, summary, severity, recommendations,
+ * provider).
+ */
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiSuccess } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { prisma } from "@/lib/db";
+import { summarize, type DataPoint } from "@/lib/analytics/trends";
+import { getBpTargets } from "@/lib/analytics/bp-targets";
+import {
+  generateAlerts,
+  type HealthAlert,
+} from "@/lib/analytics/classifications";
+import { pairByTimestamp } from "@/lib/analytics/correlations";
+import type { MeasurementType } from "@/generated/prisma/client";
+
+type Severity = "alert" | "caution" | "info" | "good";
+
+function toSeverity(level: HealthAlert["level"]): Severity {
+  switch (level) {
+    case "danger":
+      return "alert";
+    case "warning":
+      return "caution";
+    case "success":
+      return "good";
+    default:
+      return "info";
+  }
+}
+
+interface InsightRecommendation {
+  id: string;
+  label: string;
+  actionURL: string | null;
+}
+
+interface InsightCard {
+  id: string;
+  title: string;
+  summary: string;
+  body: string | null;
+  severity: Severity;
+  recommendations: InsightRecommendation[];
+  generatedAt: string;
+  provider: string;
+}
+
+export const dynamic = "force-dynamic";
+
+export const GET = apiHandler(async () => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "insights.cards" } });
+
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 86_400_000);
+
+  const [dbUser, allMeasurements, medications] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: user.id },
+      select: { heightCm: true, dateOfBirth: true, aiProvider: true },
+    }),
+    prisma.measurement.findMany({
+      where: {
+        userId: user.id,
+        type: {
+          in: [
+            "WEIGHT",
+            "BLOOD_PRESSURE_SYS",
+            "BLOOD_PRESSURE_DIA",
+            "PULSE",
+          ],
+        },
+        measuredAt: { gte: ninetyDaysAgo },
+      },
+      orderBy: { measuredAt: "asc" },
+      select: { type: true, value: true, measuredAt: true },
+    }),
+    prisma.medication.findMany({
+      where: { userId: user.id, active: true },
+      include: { schedules: true },
+    }),
+  ]);
+
+  const byType = (t: MeasurementType): DataPoint[] =>
+    allMeasurements
+      .filter((m) => m.type === t)
+      .map((m) => ({ date: m.measuredAt, value: m.value }));
+
+  const summaries: Partial<Record<MeasurementType, ReturnType<typeof summarize>>> = {};
+  for (const t of [
+    "WEIGHT",
+    "BLOOD_PRESSURE_SYS",
+    "BLOOD_PRESSURE_DIA",
+    "PULSE",
+  ] as MeasurementType[]) {
+    const data = byType(t);
+    if (data.length > 0) summaries[t] = summarize(data);
+  }
+
+  let bmi: number | null = null;
+  if (dbUser?.heightCm && summaries.WEIGHT?.latest) {
+    const heightM = dbUser.heightCm / 100;
+    bmi =
+      Math.round((summaries.WEIGHT.latest / (heightM * heightM)) * 10) / 10;
+  }
+
+  let bpPctInTarget: number | null = null;
+  const bpTargets = getBpTargets(dbUser?.dateOfBirth ?? null);
+  if (bpTargets) {
+    const sysData = byType("BLOOD_PRESSURE_SYS");
+    const diaData = byType("BLOOD_PRESSURE_DIA");
+    const pairs = pairByTimestamp(sysData, diaData, 5 * 60_000);
+    if (pairs.length > 0) {
+      const inTarget = pairs.filter(
+        (p) =>
+          p.a >= bpTargets.sysLow &&
+          p.a <= bpTargets.sysHigh &&
+          p.b >= bpTargets.diaLow &&
+          p.b <= bpTargets.diaHigh,
+      ).length;
+      bpPctInTarget = Math.round((inTarget / pairs.length) * 100);
+    }
+  }
+
+  // Lightweight medication compliance for alert input.
+  const medicationCompliance: Array<{
+    name: string;
+    compliance7: number;
+    compliance30: number;
+  }> = [];
+  for (const med of medications) {
+    if (med.schedules.length === 0) continue;
+    const events = await prisma.medicationIntakeEvent.findMany({
+      where: {
+        userId: user.id,
+        medicationId: med.id,
+        scheduledFor: { gte: new Date(Date.now() - 30 * 86_400_000) },
+      },
+      select: { takenAt: true, skipped: true, scheduledFor: true },
+    });
+    const takenLast7 = events.filter(
+      (e) =>
+        e.takenAt !== null &&
+        !e.skipped &&
+        e.scheduledFor.getTime() >= Date.now() - 7 * 86_400_000,
+    ).length;
+    const taken30 = events.filter((e) => e.takenAt !== null && !e.skipped).length;
+    const expected7 = med.schedules.length * 7;
+    const expected30 = med.schedules.length * 30;
+    medicationCompliance.push({
+      name: med.name,
+      compliance7: expected7 > 0 ? Math.round((takenLast7 / expected7) * 100) : 0,
+      compliance30:
+        expected30 > 0 ? Math.round((taken30 / expected30) * 100) : 0,
+    });
+  }
+
+  const alerts = generateAlerts({
+    bmi,
+    bpAvgSys: summaries.BLOOD_PRESSURE_SYS?.avg30 ?? null,
+    bpAvgDia: summaries.BLOOD_PRESSURE_DIA?.avg30 ?? null,
+    bpPctInTarget,
+    weightSlope30: summaries.WEIGHT?.slope30?.slope ?? null,
+    pulseAvg30: summaries.PULSE?.avg30 ?? null,
+    pulseAnomalyCount: summaries.PULSE?.anomalyCount,
+    medications: medicationCompliance,
+  });
+
+  const provider = dbUser?.aiProvider?.toLowerCase() ?? "claude";
+  const generatedAt = new Date().toISOString();
+
+  const cards: InsightCard[] = alerts.map((alert, idx) => ({
+    id: `alert-${idx + 1}`,
+    title: alert.title,
+    summary: alert.message,
+    body: null,
+    severity: toSeverity(alert.level),
+    recommendations: [],
+    generatedAt,
+    provider,
+  }));
+
+  return apiSuccess(cards);
+});

--- a/src/app/api/insights/correlations/__tests__/route.test.ts
+++ b/src/app/api/insights/correlations/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { auditLog: { create: vi.fn() } },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET } from "../route";
+import { getSession } from "@/lib/auth/session";
+import { auditLog } from "@/lib/auth/audit";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const callGet = GET as unknown as (req: NextRequest) => Promise<Response>;
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/insights/correlations");
+}
+
+describe("GET /api/insights/correlations", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an empty array as the placeholder", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await callGet(makeReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toEqual([]);
+  });
+
+  it("writes the empty-state audit log", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    await callGet(makeReq());
+    expect(auditLog).toHaveBeenCalledWith(
+      "insights.correlations.empty",
+      expect.objectContaining({ userId: "user-1" }),
+    );
+  });
+});

--- a/src/app/api/insights/correlations/route.ts
+++ b/src/app/api/insights/correlations/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /api/insights/correlations — placeholder iOS endpoint.
+ *
+ * The full correlations engine is part of `/api/insights/comprehensive`
+ * and is intentionally not re-exposed yet — iOS only needs a stable
+ * shape to render the empty state. We return `[]` and emit an audit log
+ * so the gap is visible until Phase 7 fills it in.
+ */
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiSuccess } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { auditLog } from "@/lib/auth/audit";
+
+export const dynamic = "force-dynamic";
+
+export const GET = apiHandler(async () => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "insights.correlations" } });
+
+  await auditLog("insights.correlations.empty", {
+    userId: user.id,
+    details: { reason: "phase7_pending" },
+  });
+
+  return apiSuccess([]);
+});

--- a/src/app/api/integrations/healthkit/__tests__/route.test.ts
+++ b/src/app/api/integrations/healthkit/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET, PATCH } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    healthKitConfigJson: null,
+    healthKitLastSyncedAt: null,
+  } as never);
+  vi.mocked(prisma.user.update).mockResolvedValue({} as never);
+});
+
+const callGet = GET as unknown as (req: NextRequest) => Promise<Response>;
+function makeGetReq(): NextRequest {
+  return new NextRequest("http://localhost/api/integrations/healthkit");
+}
+
+describe("GET /api/integrations/healthkit", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await callGet(makeGetReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the default entries when nothing is stored", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await callGet(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { entries: Array<{ id: string; direction: string }> };
+    };
+    expect(body.data.entries.length).toBeGreaterThan(0);
+    const bodyMass = body.data.entries.find((e) => e.id === "bodyMass");
+    expect(bodyMass?.direction).toBe("bidirectional");
+  });
+});
+
+describe("PATCH /api/integrations/healthkit", () => {
+  function req(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/integrations/healthkit", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await PATCH(req({ entries: [] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 for invalid direction", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await PATCH(
+      req({ entries: [{ id: "bodyMass", direction: "FOO" }] }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("updates known entries and silently ignores unknown ids", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await PATCH(
+      req({
+        entries: [
+          { id: "bodyMass", direction: "readOnly" },
+          { id: "totallyUnknown", direction: "bidirectional" },
+        ],
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(prisma.user.update).toHaveBeenCalledTimes(1);
+    const updateArgs = vi.mocked(prisma.user.update).mock.calls[0][0] as unknown as {
+      data: { healthKitConfigJson: { entries: Array<{ id: string }> } };
+    };
+    const ids = updateArgs.data.healthKitConfigJson.entries.map((e) => e.id);
+    expect(ids).toContain("bodyMass");
+    expect(ids).not.toContain("totallyUnknown");
+  });
+});

--- a/src/app/api/integrations/healthkit/route.ts
+++ b/src/app/api/integrations/healthkit/route.ts
@@ -1,0 +1,185 @@
+/**
+ * HealthKit (iOS) integration config.
+ *
+ * Persisted on `User.healthKitConfigJson` as `{ entries: [...] }`.
+ * Each entry: `{ id, kind, direction, enabled }` where `direction` is one
+ * of `bidirectional | readOnly | writeOnly`.
+ *
+ * GET   → resolved config (with default entries when nothing is stored).
+ * PATCH → merge by `id`; unknown ids are silently ignored.
+ */
+import { NextRequest } from "next/server";
+import { z } from "zod/v4";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiError, apiSuccess, safeJson } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { prisma } from "@/lib/db";
+import { Prisma } from "@/generated/prisma/client";
+import { auditLog } from "@/lib/auth/audit";
+
+export const directionEnum = z.enum([
+  "bidirectional",
+  "readOnly",
+  "writeOnly",
+  "disabled",
+]);
+
+const entrySchema = z.object({
+  id: z.string().min(1).max(64),
+  kind: z.string().min(1).max(64).optional(),
+  direction: directionEnum,
+  enabled: z.boolean().optional(),
+});
+
+const patchSchema = z.object({
+  entries: z.array(entrySchema).max(50),
+});
+
+export interface HealthKitEntry {
+  id: string;
+  kind: string;
+  direction: z.infer<typeof directionEnum>;
+  enabled: boolean;
+}
+
+export const DEFAULT_HEALTHKIT_ENTRIES: HealthKitEntry[] = [
+  { id: "bodyMass", kind: "bodyMass", direction: "bidirectional", enabled: true },
+  { id: "bp", kind: "bloodPressure", direction: "bidirectional", enabled: true },
+  { id: "glucose", kind: "bloodGlucose", direction: "bidirectional", enabled: true },
+  { id: "heartRate", kind: "heartRate", direction: "readOnly", enabled: true },
+  { id: "stepCount", kind: "stepCount", direction: "readOnly", enabled: true },
+  { id: "sleep", kind: "sleepAnalysis", direction: "readOnly", enabled: true },
+];
+
+interface StoredConfig {
+  entries: HealthKitEntry[];
+}
+
+function parseStored(json: unknown): StoredConfig | null {
+  if (!json || typeof json !== "object") return null;
+  const obj = json as Record<string, unknown>;
+  const entries = obj.entries;
+  if (!Array.isArray(entries)) return null;
+  const out: HealthKitEntry[] = [];
+  for (const raw of entries) {
+    if (!raw || typeof raw !== "object") continue;
+    const e = raw as Record<string, unknown>;
+    const id = typeof e.id === "string" ? e.id : null;
+    const kind = typeof e.kind === "string" ? e.kind : id;
+    const directionRaw = typeof e.direction === "string" ? e.direction : null;
+    if (!id || !kind || !directionRaw) continue;
+    const dir = directionEnum.safeParse(directionRaw);
+    if (!dir.success) continue;
+    out.push({
+      id,
+      kind,
+      direction: dir.data,
+      enabled: typeof e.enabled === "boolean" ? e.enabled : true,
+    });
+  }
+  return { entries: out };
+}
+
+function mergeWithDefaults(stored: StoredConfig | null): HealthKitEntry[] {
+  const map = new Map<string, HealthKitEntry>();
+  for (const def of DEFAULT_HEALTHKIT_ENTRIES) {
+    map.set(def.id, { ...def });
+  }
+  if (stored) {
+    for (const entry of stored.entries) {
+      const existing = map.get(entry.id);
+      if (existing) {
+        map.set(entry.id, { ...existing, ...entry });
+      } else {
+        // Surface custom keys the user has added.
+        map.set(entry.id, { ...entry, enabled: entry.enabled ?? true });
+      }
+    }
+  }
+  return [...map.values()];
+}
+
+export const GET = apiHandler(async () => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "integrations.healthkit.get" } });
+
+  const row = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { healthKitConfigJson: true, healthKitLastSyncedAt: true },
+  });
+
+  const stored = parseStored(row?.healthKitConfigJson ?? null);
+  const entries = mergeWithDefaults(stored);
+
+  return apiSuccess({
+    entries,
+    lastSyncedAt: row?.healthKitLastSyncedAt?.toISOString() ?? null,
+  });
+});
+
+export const PATCH = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const { data: body, error } = await safeJson(request);
+  if (error) return error;
+
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return apiError(parsed.error.issues[0].message, 422);
+  }
+
+  const row = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { healthKitConfigJson: true },
+  });
+  const stored = parseStored(row?.healthKitConfigJson ?? null);
+
+  // Resolve known ids set: default ids + already-stored ids.
+  const knownIds = new Set<string>(
+    DEFAULT_HEALTHKIT_ENTRIES.map((e) => e.id),
+  );
+  if (stored) for (const e of stored.entries) knownIds.add(e.id);
+
+  // Merge by id; unknown ids are silently ignored per spec.
+  const map = new Map<string, HealthKitEntry>();
+  if (stored) for (const e of stored.entries) map.set(e.id, e);
+  for (const update of parsed.data.entries) {
+    if (!knownIds.has(update.id)) continue;
+    const existing =
+      map.get(update.id) ??
+      DEFAULT_HEALTHKIT_ENTRIES.find((d) => d.id === update.id);
+    map.set(update.id, {
+      id: update.id,
+      kind: update.kind ?? existing?.kind ?? update.id,
+      direction: update.direction,
+      enabled: update.enabled ?? existing?.enabled ?? true,
+    });
+  }
+
+  const updatedConfig: StoredConfig = { entries: [...map.values()] };
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      healthKitConfigJson: updatedConfig as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  await auditLog("integrations.healthkit.update", {
+    userId: user.id,
+    details: { count: updatedConfig.entries.length },
+  });
+
+  annotate({
+    action: { name: "integrations.healthkit.update" },
+    meta: { count: updatedConfig.entries.length },
+  });
+
+  // Return resolved config (defaults merged) so the client always sees a
+  // complete entries list.
+  const merged = mergeWithDefaults(updatedConfig);
+  return apiSuccess({
+    entries: merged,
+    lastSyncedAt: null,
+  });
+});

--- a/src/app/api/measurements/route.ts
+++ b/src/app/api/measurements/route.ts
@@ -9,6 +9,8 @@ import {
   listMeasurementsSchema,
   getUnitForType,
 } from "@/lib/validations/measurement";
+import { withIdempotency } from "@/lib/idempotency";
+import { getSession } from "@/lib/auth/session";
 import { NextRequest } from "next/server";
 import type {
   MeasurementType,
@@ -16,6 +18,11 @@ import type {
   GlucoseContext,
 } from "@/generated/prisma/client";
 import { Prisma } from "@/generated/prisma/client";
+
+async function resolveUserIdForIdempotency(): Promise<string | null> {
+  const session = await getSession().catch(() => null);
+  return session?.user.id ?? null;
+}
 
 export const GET = apiHandler(async (request: NextRequest) => {
   const { user } = await requireAuth();
@@ -59,7 +66,11 @@ export const GET = apiHandler(async (request: NextRequest) => {
   });
 });
 
-export const POST = apiHandler(async (request: NextRequest) => {
+export const POST = apiHandler(
+  withIdempotency<[NextRequest]>(postMeasurement, resolveUserIdForIdempotency),
+);
+
+async function postMeasurement(request: NextRequest) {
   const { user } = await requireAuth();
 
   const { data: body, error: jsonError } = await safeJson(request);
@@ -159,4 +170,4 @@ export const POST = apiHandler(async (request: NextRequest) => {
   });
 
   return apiSuccess(measurement, 201);
-});
+}

--- a/src/app/api/measurements/series/__tests__/route.test.ts
+++ b/src/app/api/measurements/series/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: { measurement: { findMany: vi.fn() } },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+function req(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/measurements/series?${query}`);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.measurement.findMany).mockResolvedValue([] as never);
+});
+
+describe("GET /api/measurements/series", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await GET(req("kind=weight"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 for invalid kind", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await GET(req("kind=garbage"));
+    expect(res.status).toBe(422);
+  });
+
+  it("returns paired BP series with sys + dia", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const t = new Date("2026-05-01T10:00:00.000Z");
+    const findManyMock = vi.mocked(prisma.measurement.findMany);
+    findManyMock.mockImplementation(((args: unknown) => {
+      const a = args as { where: { type: string } };
+      if (a.where.type === "BLOOD_PRESSURE_SYS") {
+        return Promise.resolve([
+          { id: "s1", value: 126, measuredAt: t },
+        ]) as never;
+      }
+      if (a.where.type === "BLOOD_PRESSURE_DIA") {
+        return Promise.resolve([
+          {
+            id: "d1",
+            value: 82,
+            measuredAt: new Date(t.getTime() + 60_000),
+          },
+        ]) as never;
+      }
+      return Promise.resolve([]) as never;
+    }) as never);
+    const res = await GET(req("kind=bloodPressure&days=30"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        kind: string;
+        points: Array<{ value: number; secondary: number | null }>;
+        stats: { count: number };
+      };
+    };
+    expect(body.data.kind).toBe("bloodPressure");
+    expect(body.data.points).toHaveLength(1);
+    expect(body.data.points[0].value).toBe(126);
+    expect(body.data.points[0].secondary).toBe(82);
+    expect(body.data.stats.count).toBe(1);
+  });
+
+  it("returns single-value series for kind=weight", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.measurement.findMany).mockResolvedValue([
+      { id: "w1", value: 78.4, measuredAt: new Date() },
+    ] as never);
+    const res = await GET(req("kind=weight&days=7"));
+    const body = (await res.json()) as {
+      data: { points: Array<{ secondary: number | null }> };
+    };
+    expect(body.data.points[0].secondary).toBeNull();
+  });
+});

--- a/src/app/api/measurements/series/route.ts
+++ b/src/app/api/measurements/series/route.ts
@@ -1,0 +1,154 @@
+/**
+ * GET /api/measurements/series?kind=&days=
+ *
+ * iOS-friendly time-series adapter. Maps the camelCase `kind` to the
+ * canonical Prisma `MeasurementType`(s) and returns
+ *   { kind, points: [{ id, at, value, secondary }], stats }
+ *
+ * The `kind=bloodPressure` case pairs systolic + diastolic by
+ * `measuredAt` so iOS can render the dual-line chart with one fetch.
+ */
+import { NextRequest } from "next/server";
+import { z } from "zod/v4";
+import { prisma } from "@/lib/db";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { summarize, type DataPoint } from "@/lib/analytics/trends";
+import type { MeasurementType } from "@/generated/prisma/client";
+
+const kindEnum = z.enum([
+  "weight",
+  "bloodPressure",
+  "pulse",
+  "bodyFat",
+  "glucose",
+  "sleep",
+  "steps",
+]);
+
+const querySchema = z.object({
+  kind: kindEnum,
+  days: z.coerce.number().int().min(1).max(365).optional().default(30),
+});
+
+const KIND_TO_TYPE: Record<z.infer<typeof kindEnum>, MeasurementType> = {
+  weight: "WEIGHT",
+  bloodPressure: "BLOOD_PRESSURE_SYS",
+  pulse: "PULSE",
+  bodyFat: "BODY_FAT",
+  glucose: "BLOOD_GLUCOSE",
+  sleep: "SLEEP_DURATION",
+  steps: "ACTIVITY_STEPS",
+};
+
+interface SeriesPoint {
+  id: string;
+  at: string;
+  value: number;
+  secondary: number | null;
+}
+
+function stdDev(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((sum, v) => sum + v, 0) / values.length;
+  const variance =
+    values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return Math.round(Math.sqrt(variance) * 100) / 100;
+}
+
+export const GET = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const parsed = querySchema.safeParse(
+    Object.fromEntries(request.nextUrl.searchParams),
+  );
+  if (!parsed.success) {
+    return apiError(parsed.error.issues[0].message, 422);
+  }
+
+  const { kind, days } = parsed.data;
+  const since = new Date(Date.now() - days * 86_400_000);
+
+  let points: SeriesPoint[] = [];
+  if (kind === "bloodPressure") {
+    const [sys, dia] = await Promise.all([
+      prisma.measurement.findMany({
+        where: {
+          userId: user.id,
+          type: "BLOOD_PRESSURE_SYS",
+          measuredAt: { gte: since },
+        },
+        orderBy: { measuredAt: "asc" },
+        select: { id: true, value: true, measuredAt: true },
+      }),
+      prisma.measurement.findMany({
+        where: {
+          userId: user.id,
+          type: "BLOOD_PRESSURE_DIA",
+          measuredAt: { gte: since },
+        },
+        orderBy: { measuredAt: "asc" },
+        select: { id: true, value: true, measuredAt: true },
+      }),
+    ]);
+
+    // Pair by closest timestamp within ±5 minutes.
+    const PAIR_WINDOW_MS = 5 * 60_000;
+    points = sys.map((s) => {
+      let bestDia: { value: number; dt: number } | null = null;
+      for (const d of dia) {
+        const dt = Math.abs(d.measuredAt.getTime() - s.measuredAt.getTime());
+        if (dt > PAIR_WINDOW_MS) continue;
+        if (!bestDia || dt < bestDia.dt) {
+          bestDia = { value: d.value, dt };
+        }
+      }
+      return {
+        id: s.id,
+        at: s.measuredAt.toISOString(),
+        value: s.value,
+        secondary: bestDia?.value ?? null,
+      };
+    });
+  } else {
+    const type = KIND_TO_TYPE[kind];
+    const rows = await prisma.measurement.findMany({
+      where: { userId: user.id, type, measuredAt: { gte: since } },
+      orderBy: { measuredAt: "asc" },
+      select: { id: true, value: true, measuredAt: true },
+    });
+    points = rows.map((r) => ({
+      id: r.id,
+      at: r.measuredAt.toISOString(),
+      value: r.value,
+      secondary: null,
+    }));
+  }
+
+  const dataPoints: DataPoint[] = points.map((p) => ({
+    date: new Date(p.at),
+    value: p.value,
+  }));
+  const summary = dataPoints.length > 0 ? summarize(dataPoints) : null;
+  const values = dataPoints.map((p) => p.value);
+
+  annotate({
+    action: { name: "measurements.series" },
+    meta: { kind, days, count: points.length },
+  });
+
+  return apiSuccess({
+    kind,
+    points,
+    stats: summary
+      ? {
+          mean: summary.mean,
+          min: summary.min,
+          max: summary.max,
+          stdDev: stdDev(values),
+          count: summary.count,
+        }
+      : { mean: 0, min: 0, max: 0, stdDev: 0, count: 0 },
+  });
+});

--- a/src/app/api/medications/[id]/intake/route.ts
+++ b/src/app/api/medications/[id]/intake/route.ts
@@ -7,11 +7,25 @@ import {
   intakeSchema,
   listIntakeEventsSchema,
 } from "@/lib/validations/medication";
+import { withIdempotency } from "@/lib/idempotency";
+import { getSession } from "@/lib/auth/session";
 import { NextRequest } from "next/server";
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-export const POST = apiHandler(async (request: NextRequest, { params }: RouteParams) => {
+async function resolveUserIdForIdempotency(): Promise<string | null> {
+  const session = await getSession().catch(() => null);
+  return session?.user.id ?? null;
+}
+
+export const POST = apiHandler(
+  withIdempotency<[NextRequest, RouteParams]>(
+    postIntake,
+    resolveUserIdForIdempotency,
+  ),
+);
+
+async function postIntake(request: NextRequest, { params }: RouteParams) {
   const { user } = await requireAuth();
 
   const { id } = await params;
@@ -100,7 +114,7 @@ export const POST = apiHandler(async (request: NextRequest, { params }: RoutePar
   });
 
   return apiSuccess(event, 201);
-});
+}
 
 export const GET = apiHandler(async (request: NextRequest, { params }: RouteParams) => {
   const { user } = await requireAuth();

--- a/src/app/api/medications/intake/__tests__/route.test.ts
+++ b/src/app/api/medications/intake/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    medicationIntakeEvent: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    medication: { update: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET, POST } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([] as never);
+});
+
+describe("GET /api/medications/intake", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await GET(
+      new NextRequest("http://localhost/api/medications/intake?scope=today"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 for invalid scope", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await GET(
+      new NextRequest("http://localhost/api/medications/intake?scope=junk"),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("returns today's events as a flat array", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([
+      {
+        id: "e1",
+        medicationId: "m1",
+        scheduledFor: new Date(),
+        takenAt: null,
+        skipped: false,
+        medication: { id: "m1", snoozedUntil: null },
+      },
+    ] as never);
+    const res = await GET(
+      new NextRequest("http://localhost/api/medications/intake?scope=today"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ id: string; status: string }>;
+    };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].status).toBe("pending");
+  });
+
+  it("returns compliance buckets for the last N days", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.medicationIntakeEvent.findMany).mockResolvedValue([
+      {
+        scheduledFor: new Date(),
+        takenAt: new Date(),
+        skipped: false,
+      },
+    ] as never);
+    const res = await GET(
+      new NextRequest(
+        "http://localhost/api/medications/intake?scope=compliance&days=7",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ date: string; scheduled: number; taken: number }>;
+    };
+    expect(body.data.length).toBe(7);
+  });
+});
+
+describe("POST /api/medications/intake", () => {
+  function req(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/medications/intake", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await POST(req({ intakeId: "e1", status: "taken" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when the event isn't owned by the user", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.medicationIntakeEvent.findUnique).mockResolvedValue({
+      id: "e1",
+      userId: "someone-else",
+      medicationId: "m1",
+    } as never);
+    const res = await POST(req({ intakeId: "e1", status: "taken" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 422 for invalid status", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await POST(req({ intakeId: "e1", status: "broken" }));
+    expect(res.status).toBe(422);
+  });
+
+  it("marks event as skipped", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.medicationIntakeEvent.findUnique).mockResolvedValue({
+      id: "e1",
+      userId: "user-1",
+      medicationId: "m1",
+    } as never);
+    vi.mocked(prisma.medicationIntakeEvent.update).mockResolvedValue({
+      id: "e1",
+      skipped: true,
+      takenAt: null,
+    } as never);
+    const res = await POST(req({ intakeId: "e1", status: "skipped" }));
+    expect(res.status).toBe(200);
+    expect(prisma.medicationIntakeEvent.update).toHaveBeenCalledWith({
+      where: { id: "e1" },
+      data: { takenAt: null, skipped: true },
+    });
+  });
+});

--- a/src/app/api/medications/intake/route.ts
+++ b/src/app/api/medications/intake/route.ts
@@ -1,0 +1,201 @@
+/**
+ * Top-level medication-intake aggregator + writer.
+ *
+ *   GET  /api/medications/intake?scope=today
+ *     → array of today's intake events for the user (across medications).
+ *
+ *   GET  /api/medications/intake?scope=compliance&days=N
+ *     → per-day { date, scheduled, taken } for the last N days.
+ *
+ *   POST /api/medications/intake
+ *     Body: { intakeId, status: "taken" | "skipped" | "snoozed", takenAt?, snoozedUntil? }
+ *     Updates the named MedicationIntakeEvent and returns the updated row.
+ */
+import { NextRequest } from "next/server";
+import { z } from "zod/v4";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiError, apiSuccess, getClientIp, safeJson } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { prisma } from "@/lib/db";
+import { auditLog } from "@/lib/auth/audit";
+
+const querySchema = z.object({
+  scope: z.enum(["today", "compliance"]),
+  days: z.coerce.number().int().min(1).max(365).optional().default(30),
+});
+
+const updateSchema = z.object({
+  intakeId: z.string().min(1),
+  status: z.enum(["taken", "skipped", "snoozed"]),
+  takenAt: z.iso
+    .datetime({ offset: true })
+    .transform((s) => new Date(s))
+    .optional(),
+  snoozedUntil: z.iso
+    .datetime({ offset: true })
+    .transform((s) => new Date(s))
+    .optional(),
+});
+
+function startOfDayBerlin(date: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/Berlin",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const y = parts.find((p) => p.type === "year")?.value ?? "1970";
+  const m = parts.find((p) => p.type === "month")?.value ?? "01";
+  const d = parts.find((p) => p.type === "day")?.value ?? "01";
+  return new Date(`${y}-${m}-${d}T00:00:00.000Z`);
+}
+
+function berlinDayKey(date: Date): string {
+  return new Intl.DateTimeFormat("sv-SE", {
+    timeZone: "Europe/Berlin",
+  }).format(date);
+}
+
+export const GET = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const parsed = querySchema.safeParse(
+    Object.fromEntries(request.nextUrl.searchParams),
+  );
+  if (!parsed.success) {
+    return apiError(parsed.error.issues[0].message, 422);
+  }
+
+  const { scope, days } = parsed.data;
+
+  if (scope === "today") {
+    const todayStart = startOfDayBerlin(new Date());
+    const todayEnd = new Date(todayStart.getTime() + 86_400_000);
+    const events = await prisma.medicationIntakeEvent.findMany({
+      where: {
+        userId: user.id,
+        scheduledFor: { gte: todayStart, lt: todayEnd },
+      },
+      orderBy: { scheduledFor: "asc" },
+      include: { medication: { select: { id: true, snoozedUntil: true } } },
+    });
+
+    annotate({
+      action: { name: "medications.intake.today" },
+      meta: { count: events.length },
+    });
+
+    return apiSuccess(
+      events.map((e) => ({
+        id: e.id,
+        medicationId: e.medicationId,
+        scheduledAt: e.scheduledFor.toISOString(),
+        takenAt: e.takenAt?.toISOString() ?? null,
+        status: e.skipped
+          ? "skipped"
+          : e.takenAt
+            ? "taken"
+            : e.medication.snoozedUntil &&
+                e.medication.snoozedUntil > new Date()
+              ? "snoozed"
+              : "pending",
+        snoozedUntil: e.medication.snoozedUntil?.toISOString() ?? null,
+      })),
+    );
+  }
+
+  // compliance: per-day scheduled vs taken for the last N days
+  const start = new Date(Date.now() - days * 86_400_000);
+  const events = await prisma.medicationIntakeEvent.findMany({
+    where: { userId: user.id, scheduledFor: { gte: start } },
+    select: { scheduledFor: true, takenAt: true, skipped: true },
+  });
+
+  const buckets = new Map<string, { scheduled: number; taken: number }>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(Date.now() - i * 86_400_000);
+    buckets.set(berlinDayKey(d), { scheduled: 0, taken: 0 });
+  }
+  for (const e of events) {
+    const key = berlinDayKey(e.scheduledFor);
+    const bucket = buckets.get(key);
+    if (!bucket) continue;
+    bucket.scheduled += 1;
+    if (e.takenAt && !e.skipped) bucket.taken += 1;
+  }
+
+  const result = [...buckets.entries()]
+    .map(([date, v]) => ({ date, scheduled: v.scheduled, taken: v.taken }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  annotate({
+    action: { name: "medications.intake.compliance" },
+    meta: { days, count: result.length },
+  });
+
+  return apiSuccess(result);
+});
+
+export const POST = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const { data: body, error } = await safeJson(request);
+  if (error) return error;
+
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return apiError(parsed.error.issues[0].message, 422);
+  }
+
+  const { intakeId, status, takenAt, snoozedUntil } = parsed.data;
+
+  const existing = await prisma.medicationIntakeEvent.findUnique({
+    where: { id: intakeId },
+  });
+  if (!existing || existing.userId !== user.id) {
+    return apiError("Intake event not found", 404);
+  }
+
+  let updated;
+  if (status === "taken") {
+    [updated] = await prisma.$transaction([
+      prisma.medicationIntakeEvent.update({
+        where: { id: intakeId },
+        data: { takenAt: takenAt ?? new Date(), skipped: false },
+      }),
+      prisma.medication.update({
+        where: { id: existing.medicationId },
+        data: { snoozedUntil: null },
+      }),
+    ]);
+  } else if (status === "skipped") {
+    updated = await prisma.medicationIntakeEvent.update({
+      where: { id: intakeId },
+      data: { takenAt: null, skipped: true },
+    });
+  } else {
+    // snoozed: snoozedUntil lives on the Medication row.
+    const until =
+      snoozedUntil ?? new Date(Date.now() + 30 * 60_000); // default +30min
+    await prisma.medication.update({
+      where: { id: existing.medicationId },
+      data: { snoozedUntil: until },
+    });
+    updated = await prisma.medicationIntakeEvent.findUnique({
+      where: { id: intakeId },
+    });
+  }
+
+  await auditLog("medications.intake.update", {
+    userId: user.id,
+    ipAddress: getClientIp(request),
+    details: { intakeId, status },
+  });
+
+  annotate({
+    action: { name: "medications.intake.update" },
+    meta: { intakeId, status },
+  });
+
+  return apiSuccess(updated);
+});

--- a/src/app/api/mood-entries/route.ts
+++ b/src/app/api/mood-entries/route.ts
@@ -10,6 +10,13 @@ import { NextRequest } from "next/server";
 import { Prisma } from "@/generated/prisma/client";
 import { apiHandler, requireAuth } from "@/lib/api-handler";
 import { annotate } from "@/lib/logging/context";
+import { withIdempotency } from "@/lib/idempotency";
+import { getSession } from "@/lib/auth/session";
+
+async function resolveUserIdForIdempotency(): Promise<string | null> {
+  const session = await getSession().catch(() => null);
+  return session?.user.id ?? null;
+}
 
 function toBerlinDate(date: Date): string {
   return new Intl.DateTimeFormat("sv-SE", {
@@ -73,7 +80,11 @@ export const GET = apiHandler(async (request: NextRequest) => {
   });
 });
 
-export const POST = apiHandler(async (request: NextRequest) => {
+export const POST = apiHandler(
+  withIdempotency<[NextRequest]>(postMoodEntry, resolveUserIdForIdempotency),
+);
+
+async function postMoodEntry(request: NextRequest) {
   const { user } = await requireAuth();
 
   const { data: body, error: jsonError } = await safeJson(request);
@@ -119,4 +130,4 @@ export const POST = apiHandler(async (request: NextRequest) => {
     }
     throw err;
   }
-});
+}

--- a/src/app/api/user/profile/__tests__/route.test.ts
+++ b/src/app/api/user/profile/__tests__/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({ getSession: vi.fn() }));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({ emitIfSampled: vi.fn() }));
+
+vi.mock("@/lib/db-compat", () => ({
+  ensureDbCompatibility: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: () => null })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+import { GET, PATCH } from "../route";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+
+const SESSION_OK = {
+  session: { id: "sess-1", expiresAt: new Date(Date.now() + 3_600_000) },
+  user: { id: "user-1", username: "marc", role: "USER" as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const callGet = GET as unknown as (req: NextRequest) => Promise<Response>;
+function makeGetReq(): NextRequest {
+  return new NextRequest("http://localhost/api/user/profile");
+}
+
+describe("GET /api/user/profile", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await callGet(makeGetReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns flattened iOS-style fields", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      username: "marc",
+      displayName: "Marc B.",
+      email: "marc@example.com",
+      dateOfBirth: new Date("1985-03-12T00:00:00.000Z"),
+      gender: "MALE",
+      heightCm: 180,
+      locale: "de",
+      timezone: "Europe/Berlin",
+    } as never);
+
+    const res = await callGet(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: {
+        username: string;
+        displayName: string | null;
+        heightCm: number;
+        locale: string | null;
+      };
+    };
+    expect(body.data.username).toBe("marc");
+    expect(body.data.displayName).toBe("Marc B.");
+    expect(body.data.heightCm).toBe(180);
+    expect(body.data.locale).toBe("de");
+  });
+});
+
+describe("PATCH /api/user/profile", () => {
+  function req(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/user/profile", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    const res = await PATCH(req({ displayName: "Test" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 422 for invalid heightCm", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    const res = await PATCH(req({ heightCm: 9999 }));
+    expect(res.status).toBe(422);
+  });
+
+  it("persists displayName + locale via shared helper", async () => {
+    vi.mocked(getSession).mockResolvedValue(SESSION_OK as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.update).mockResolvedValue({
+      id: "user-1",
+      username: "marc",
+      displayName: "Marc B.",
+      email: null,
+      role: "USER",
+      heightCm: null,
+      dateOfBirth: null,
+      gender: null,
+      timezone: "Europe/Berlin",
+      locale: "de",
+    } as never);
+
+    const res = await PATCH(req({ displayName: "Marc B.", locale: "de" }));
+    expect(res.status).toBe(200);
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "user-1" },
+        data: expect.objectContaining({
+          displayName: "Marc B.",
+          locale: "de",
+        }),
+      }),
+    );
+  });
+});

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -1,0 +1,71 @@
+/**
+ * iOS-friendly user profile endpoint.
+ *
+ * GET   → flattened profile fields (camelCase) for the native client.
+ *         Aliased over the same data exposed by `/api/auth/me`.
+ * PATCH → delegates to the shared `applyProfileUpdate` helper used by
+ *         `/api/auth/profile` PUT — same validation, same audit log.
+ */
+import { NextRequest } from "next/server";
+import { apiHandler, requireAuth } from "@/lib/api-handler";
+import { apiError, apiSuccess, getClientIp, safeJson } from "@/lib/api-response";
+import { annotate } from "@/lib/logging/context";
+import { applyProfileUpdate } from "@/lib/auth/profile-update";
+import { prisma } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export const GET = apiHandler(async () => {
+  const { user } = await requireAuth();
+  annotate({ action: { name: "user.profile.get" } });
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: {
+      username: true,
+      displayName: true,
+      email: true,
+      dateOfBirth: true,
+      gender: true,
+      heightCm: true,
+      locale: true,
+      timezone: true,
+    },
+  });
+
+  return apiSuccess({
+    username: dbUser?.username ?? user.username,
+    displayName: dbUser?.displayName ?? null,
+    email: dbUser?.email ?? null,
+    dateOfBirth: dbUser?.dateOfBirth?.toISOString() ?? null,
+    gender: dbUser?.gender ?? null,
+    heightCm: dbUser?.heightCm ?? null,
+    locale: dbUser?.locale ?? null,
+    timezone: dbUser?.timezone ?? "Europe/Berlin",
+  });
+});
+
+export const PATCH = apiHandler(async (request: NextRequest) => {
+  const { user } = await requireAuth();
+
+  const { data: body, error } = await safeJson(request);
+  if (error) return error;
+
+  const result = await applyProfileUpdate(user.id, body, getClientIp(request));
+  if (!result.ok) {
+    return apiError(result.message, result.status);
+  }
+
+  annotate({ action: { name: "user.profile.update" } });
+
+  return apiSuccess({
+    username: result.user.username,
+    displayName: result.user.displayName,
+    email: result.user.email,
+    dateOfBirth: result.user.dateOfBirth?.toISOString() ?? null,
+    gender: result.user.gender,
+    heightCm: result.user.heightCm,
+    locale: result.user.locale,
+    timezone: result.user.timezone,
+  });
+});

--- a/src/lib/__tests__/doctor-report-pdf-core.test.ts
+++ b/src/lib/__tests__/doctor-report-pdf-core.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDoctorReportPdfDocument,
+  renderDoctorReportPdfBytes,
+} from "../doctor-report-pdf-core";
+import type { DoctorReportData } from "../doctor-report-data";
+import { getServerTranslator } from "../i18n/server-translator";
+
+const FIXED_NOW = new Date("2026-05-03T12:00:00.000Z");
+
+function makeData(overrides?: Partial<DoctorReportData>): DoctorReportData {
+  return {
+    period: { days: 90, since: "2026-02-02T00:00:00.000Z" },
+    patient: {
+      username: "marc",
+      dateOfBirth: "1985-06-15T00:00:00.000Z",
+      gender: "MALE",
+      heightCm: 182,
+    },
+    measurements: {
+      WEIGHT: [
+        { value: 80, measuredAt: "2026-02-10T08:00:00.000Z" },
+        { value: 79.5, measuredAt: "2026-04-30T08:00:00.000Z" },
+      ],
+    },
+    stats: {
+      WEIGHT: { avg: 79.75, min: 79.5, max: 80, count: 2, latest: 79.5 },
+      BLOOD_PRESSURE_SYS: {
+        avg: 122,
+        min: 118,
+        max: 128,
+        count: 5,
+        latest: 120,
+      },
+      BLOOD_PRESSURE_DIA: {
+        avg: 78,
+        min: 72,
+        max: 82,
+        count: 5,
+        latest: 78,
+      },
+      PULSE: { avg: 65, min: 58, max: 72, count: 5, latest: 64 },
+    },
+    glucoseStats: {
+      FASTING: { avg: 92, min: 85, max: 100, count: 4, latest: 90 },
+    },
+    glucoseRanges: { FASTING: { min: 70, max: 99 } },
+    glucoseUnit: "mg/dL",
+    bmi: 24.1,
+    compliance: {
+      Ramipril: { total: 90, taken: 85, skipped: 3, missed: 2 },
+    },
+    medications: [
+      {
+        name: "Ramipril",
+        dose: "5mg",
+        schedules: [
+          { windowStart: "08:00", windowEnd: "09:00", label: "Morning" },
+        ],
+      },
+    ],
+    mood: {
+      avg: 3.6,
+      min: 2,
+      max: 5,
+      count: 30,
+      distribution: { 1: 0, 2: 3, 3: 9, 4: 14, 5: 4 },
+    },
+    ...overrides,
+  };
+}
+
+describe("renderDoctorReportPdfBytes", () => {
+  it("returns a Uint8Array starting with the %PDF- header", () => {
+    const { t } = getServerTranslator("de");
+    const bytes = renderDoctorReportPdfBytes(makeData(), {
+      t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    const header = String.fromCharCode(...bytes.slice(0, 5));
+    expect(header).toBe("%PDF-");
+  });
+
+  it("produces a non-trivial document (> 1 KB)", () => {
+    const { t } = getServerTranslator("de");
+    const bytes = renderDoctorReportPdfBytes(makeData(), {
+      t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    expect(bytes.byteLength).toBeGreaterThan(1024);
+  });
+
+  it("is structurally deterministic for the same input + fixed timestamp", () => {
+    // jsPDF embeds a per-invocation file-id in the trailer (random UUID-like
+    // hex). The visible content is fully determined by the inputs, so we
+    // assert byte-length equality + identical content sections instead of a
+    // strict bytewise compare.
+    const { t } = getServerTranslator("de");
+    const a = renderDoctorReportPdfBytes(makeData(), {
+      t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    const b = renderDoctorReportPdfBytes(makeData(), {
+      t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    expect(a.byteLength).toBe(b.byteLength);
+    // Compare the first 95% of the document — file-id and trailer differ.
+    const cmp = Math.floor(a.byteLength * 0.95);
+    expect(
+      Buffer.from(a.slice(0, cmp)).equals(Buffer.from(b.slice(0, cmp))),
+    ).toBe(true);
+  });
+
+  it("renders both DE and EN locales without errors", () => {
+    const de = renderDoctorReportPdfBytes(makeData(), {
+      t: getServerTranslator("de").t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    const en = renderDoctorReportPdfBytes(makeData(), {
+      t: getServerTranslator("en").t,
+      locale: "en",
+      now: FIXED_NOW,
+    });
+    expect(de.byteLength).toBeGreaterThan(1024);
+    expect(en.byteLength).toBeGreaterThan(1024);
+  });
+
+  it("handles empty stats / no mood without throwing", () => {
+    const empty = makeData({
+      stats: {},
+      glucoseStats: {},
+      glucoseRanges: {},
+      compliance: {},
+      mood: null,
+      bmi: null,
+    });
+    const bytes = renderDoctorReportPdfBytes(empty, {
+      t: getServerTranslator("de").t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    const header = String.fromCharCode(...bytes.slice(0, 5));
+    expect(header).toBe("%PDF-");
+  });
+});
+
+describe("buildDoctorReportPdfDocument", () => {
+  it("returns a jsPDF doc with at least one page", () => {
+    const doc = buildDoctorReportPdfDocument(makeData(), {
+      t: getServerTranslator("de").t,
+      locale: "de",
+      now: FIXED_NOW,
+    });
+    expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/__tests__/idempotency.test.ts
+++ b/src/lib/__tests__/idempotency.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    idempotencyKey: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/logging/context", () => ({
+  annotate: vi.fn(),
+}));
+
+import { withIdempotency } from "../idempotency";
+import { prisma } from "@/lib/db";
+
+function makeRequest(
+  method: string,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest("http://localhost/api/example", {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: method === "GET" ? undefined : JSON.stringify({ ok: true }),
+  });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(prisma.idempotencyKey.findUnique).mockResolvedValue(null);
+  vi.mocked(prisma.idempotencyKey.create).mockResolvedValue({} as never);
+});
+
+describe("withIdempotency", () => {
+  it("passes through when no Idempotency-Key header is present", async () => {
+    const handler = vi.fn(async () =>
+      NextResponse.json({ data: { ok: true }, error: null }, { status: 201 }),
+    );
+    const wrapped = withIdempotency<[NextRequest]>(handler, async () => "u-1");
+    const res = await wrapped(makeRequest("POST"));
+    expect(res.status).toBe(201);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(prisma.idempotencyKey.findUnique).not.toHaveBeenCalled();
+    expect(prisma.idempotencyKey.create).not.toHaveBeenCalled();
+  });
+
+  it("caches the response and replays it on the second call", async () => {
+    let callCount = 0;
+    const handler = vi.fn(async () => {
+      callCount += 1;
+      return NextResponse.json(
+        { data: { result: callCount }, error: null },
+        { status: 201 },
+      );
+    });
+    const wrapped = withIdempotency<[NextRequest]>(handler, async () => "u-1");
+
+    // First call: nothing cached → handler runs → response stored.
+    const req1 = makeRequest("POST", { "idempotency-key": "abc-12345678" });
+    const res1 = await wrapped(req1);
+    const body1 = await res1.json();
+    expect(res1.status).toBe(201);
+    expect(body1).toEqual({ data: { result: 1 }, error: null });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(prisma.idempotencyKey.create).toHaveBeenCalledTimes(1);
+
+    // Capture the persisted body for replay.
+    const persistedBody = (
+      vi.mocked(prisma.idempotencyKey.create).mock.calls[0][0] as {
+        data: { responseBody: string; responseStatus: number };
+      }
+    ).data;
+
+    // Second call: cache hit returns persisted envelope.
+    vi.mocked(prisma.idempotencyKey.findUnique).mockResolvedValueOnce({
+      id: "idem-1",
+      userId: "u-1",
+      key: "abc-12345678",
+      method: "POST",
+      path: "/api/example",
+      responseStatus: persistedBody.responseStatus,
+      responseBody: persistedBody.responseBody,
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: new Date(),
+    } as never);
+
+    const req2 = makeRequest("POST", { "idempotency-key": "abc-12345678" });
+    const res2 = await wrapped(req2);
+    expect(res2.headers.get("X-Idempotent-Replay")).toBe("true");
+    expect(res2.status).toBe(201);
+    const body2 = await res2.json();
+    expect(body2).toEqual({ data: { result: 1 }, error: null });
+    expect(handler).toHaveBeenCalledTimes(1); // not called again
+  });
+
+  it("ignores expired cache rows and re-runs the handler", async () => {
+    const handler = vi.fn(async () =>
+      NextResponse.json({ data: "fresh", error: null }, { status: 200 }),
+    );
+    vi.mocked(prisma.idempotencyKey.findUnique).mockResolvedValueOnce({
+      id: "idem-old",
+      userId: "u-1",
+      key: "abc-12345678",
+      method: "POST",
+      path: "/api/example",
+      responseStatus: 200,
+      responseBody: '{"data":"stale","error":null}',
+      expiresAt: new Date(Date.now() - 1000),
+      createdAt: new Date(),
+    } as never);
+    vi.mocked(prisma.idempotencyKey.delete).mockResolvedValue({} as never);
+
+    const wrapped = withIdempotency<[NextRequest]>(handler, async () => "u-1");
+    const res = await wrapped(
+      makeRequest("POST", { "idempotency-key": "abc-12345678" }),
+    );
+    const body = await res.json();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(body).toEqual({ data: "fresh", error: null });
+    expect(prisma.idempotencyKey.delete).toHaveBeenCalled();
+  });
+
+  it("ignores malformed Idempotency-Key headers", async () => {
+    const handler = vi.fn(async () =>
+      NextResponse.json({ data: "ok", error: null }),
+    );
+    const wrapped = withIdempotency<[NextRequest]>(handler, async () => "u-1");
+    await wrapped(makeRequest("POST", { "idempotency-key": "!!" }));
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(prisma.idempotencyKey.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for GET requests", async () => {
+    const handler = vi.fn(async () =>
+      NextResponse.json({ data: "ok", error: null }),
+    );
+    const wrapped = withIdempotency<[NextRequest]>(handler, async () => "u-1");
+    await wrapped(makeRequest("GET", { "idempotency-key": "abc-12345678" }));
+    expect(prisma.idempotencyKey.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/require-auth-bearer.test.ts
+++ b/src/lib/__tests__/require-auth-bearer.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// --- Mocks must be hoisted before importing the module under test. ---
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    apiToken: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/hmac", () => ({
+  hashToken: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/audit", () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging/transports", () => ({
+  emitIfSampled: vi.fn(),
+}));
+
+const headersGet = vi.fn<(name: string) => string | null>();
+vi.mock("next/headers", () => ({
+  headers: vi.fn(async () => ({ get: headersGet })),
+  cookies: vi.fn(async () => ({ get: () => undefined, set: () => {}, delete: () => {} })),
+}));
+
+// --- Imports use the mocked modules above. ---
+
+import { requireAuth, HttpError } from "../api-handler";
+import { prisma } from "@/lib/db";
+import { getSession } from "@/lib/auth/session";
+import { hashToken } from "@/lib/auth/hmac";
+import { auditLog } from "@/lib/auth/audit";
+
+const FAKE_HASH = "deadbeefcafef00d";
+const RAW_TOKEN = "hlk_" + "a".repeat(64);
+
+const FAKE_USER = {
+  id: "user-1",
+  role: "USER" as const,
+  username: "marc",
+  email: "marc@example.com",
+};
+
+function setBearerHeader(value: string | null): void {
+  headersGet.mockReset();
+  headersGet.mockImplementation((name: string) =>
+    name.toLowerCase() === "authorization" ? value : null,
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(hashToken).mockReturnValue(FAKE_HASH);
+  vi.mocked(prisma.apiToken.update).mockResolvedValue({} as never);
+  vi.mocked(auditLog).mockResolvedValue(undefined as never);
+});
+
+describe("requireAuth — Bearer token path", () => {
+  it("authenticates a valid Bearer token and returns AuthContext", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    vi.mocked(prisma.apiToken.findUnique).mockResolvedValue({
+      id: "token-1",
+      userId: "user-1",
+      permissions: ["medication:ingest"],
+      revoked: false,
+      expiresAt,
+    } as never);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(FAKE_USER as never);
+
+    const ctx = await requireAuth();
+
+    expect(hashToken).toHaveBeenCalledWith(RAW_TOKEN);
+    expect(ctx.user.id).toBe("user-1");
+    expect(ctx.session.id).toBe("token-1");
+    expect(ctx.session.expiresAt).toEqual(expiresAt);
+
+    // lastUsedAt refresh is fire-and-forget but should still have been triggered.
+    expect(prisma.apiToken.update).toHaveBeenCalledWith({
+      where: { id: "token-1" },
+      data: { lastUsedAt: expect.any(Date) },
+    });
+    expect(auditLog).toHaveBeenCalledWith(
+      "auth.bearer.success",
+      expect.objectContaining({ userId: "user-1" }),
+    );
+  });
+
+  it("rejects a revoked token with 401", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    vi.mocked(prisma.apiToken.findUnique).mockResolvedValue({
+      id: "token-2",
+      userId: "user-1",
+      permissions: [],
+      revoked: true,
+      expiresAt: null,
+    } as never);
+
+    await expect(requireAuth()).rejects.toMatchObject({
+      statusCode: 401,
+    } satisfies Partial<HttpError>);
+    expect(auditLog).toHaveBeenCalledWith(
+      "auth.bearer.failure",
+      expect.objectContaining({
+        details: expect.objectContaining({ reason: "revoked" }),
+      }),
+    );
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects an expired token with 401", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    vi.mocked(prisma.apiToken.findUnique).mockResolvedValue({
+      id: "token-3",
+      userId: "user-1",
+      permissions: [],
+      revoked: false,
+      expiresAt: new Date(Date.now() - 60_000),
+    } as never);
+
+    await expect(requireAuth()).rejects.toMatchObject({ statusCode: 401 });
+    expect(auditLog).toHaveBeenCalledWith(
+      "auth.bearer.failure",
+      expect.objectContaining({
+        details: expect.objectContaining({ reason: "expired" }),
+      }),
+    );
+  });
+
+  it("rejects an unknown token with 401", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    vi.mocked(prisma.apiToken.findUnique).mockResolvedValue(null);
+
+    await expect(requireAuth()).rejects.toMatchObject({ statusCode: 401 });
+    expect(auditLog).toHaveBeenCalledWith(
+      "auth.bearer.failure",
+      expect.objectContaining({
+        details: expect.objectContaining({ reason: "unknown_token" }),
+      }),
+    );
+  });
+
+  it("rejects a Bearer token missing the requested permission with 403", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    vi.mocked(prisma.apiToken.findUnique).mockResolvedValue({
+      id: "token-4",
+      userId: "user-1",
+      permissions: ["something:else"],
+      revoked: false,
+      expiresAt: null,
+    } as never);
+
+    await expect(requireAuth("medication:ingest")).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(auditLog).toHaveBeenCalledWith(
+      "auth.bearer.failure",
+      expect.objectContaining({
+        details: expect.objectContaining({
+          reason: "insufficient_permissions",
+          required: "medication:ingest",
+        }),
+      }),
+    );
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when neither cookie nor Bearer is present", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    setBearerHeader(null);
+
+    await expect(requireAuth()).rejects.toMatchObject({ statusCode: 401 });
+    expect(prisma.apiToken.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("requireAuth — cookie path remains intact", () => {
+  it("returns the session payload without consulting the Bearer header", async () => {
+    const cookieSession = {
+      session: { id: "sess-1", expiresAt: new Date(Date.now() + 3600_000) },
+      user: { ...FAKE_USER, role: "USER" as const },
+    };
+    vi.mocked(getSession).mockResolvedValue(cookieSession as never);
+    // Even if a Bearer header is present, the cookie wins (existing behaviour).
+    setBearerHeader(`Bearer ${RAW_TOKEN}`);
+
+    const ctx = await requireAuth("medication:ingest");
+
+    expect(ctx).toEqual(cookieSession);
+    // Cookie short-circuits before any token logic runs.
+    expect(prisma.apiToken.findUnique).not.toHaveBeenCalled();
+    expect(hashToken).not.toHaveBeenCalled();
+    expect(auditLog).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+import type { User } from "@/generated/prisma/client";
 import { WideEventBuilder } from "./logging/event-builder";
 import { eventStorage, getEvent } from "./logging/context";
 import { emitIfSampled } from "./logging/transports";
 import { getSession } from "./auth/session";
+import { hashToken } from "./auth/hmac";
+import { prisma } from "./db";
+import { auditLog } from "./auth/audit";
 
 /**
  * Custom error class for HTTP errors with status codes.
@@ -98,17 +103,176 @@ export function apiHandler<T extends (...args: any[]) => Promise<Response>>(
 }
 
 /**
- * Require an authenticated session. Throws HttpError(401) if not authenticated.
+ * Authenticated request context. Returned by both session-cookie and Bearer-token
+ * authentication paths. The `session.id` is the session-record id for cookie auth
+ * and the `ApiToken` id for bearer auth — callers must not assume the id refers
+ * to a Session row.
+ */
+export type AuthContext = {
+  session: { id: string; expiresAt: Date };
+  user: User;
+};
+
+/**
+ * Require an authenticated request. Throws HttpError(401) / HttpError(403) on failure.
+ *
+ * Auth precedence (cookie-first, never both):
+ *   1. Valid session cookie → cookie path (existing behaviour, requiredPermission ignored).
+ *   2. No cookie + `Authorization: Bearer hlk_<...>` → API token path.
+ *   3. Neither → 401.
+ *
+ * @param requiredPermission Optional permission scope. Only enforced for Bearer
+ *   auth — cookie sessions always pass (full user access). When set and missing
+ *   from `ApiToken.permissions`, throws HttpError(403).
+ */
+export async function requireAuth(
+  requiredPermission?: string,
+): Promise<AuthContext> {
+  // 1. Session cookie path — unchanged.
+  const sessionData = await getSession();
+  if (sessionData) {
+    const evt = getEvent();
+    if (evt) {
+      evt.setAuth({
+        user_id: sessionData.user.id,
+        user_role: sessionData.user.role,
+        auth_method: "session",
+      });
+    }
+    return sessionData;
+  }
+
+  // 2. Bearer-token path.
+  // `headers()` is only valid inside a Next.js request scope. Outside one
+  // (e.g. during direct unit tests of legacy routes that pre-date Bearer auth)
+  // we treat the absence of a header context as "no Bearer present" and fall
+  // through to the unauthenticated case below.
+  let authHeader: string | null = null;
+  try {
+    const headerList = await headers();
+    authHeader = headerList.get("authorization");
+  } catch {
+    authHeader = null;
+  }
+  if (authHeader?.startsWith("Bearer ")) {
+    return await authenticateBearer(authHeader.slice(7), requiredPermission);
+  }
+
+  // 3. No credentials.
+  throw new HttpError(401, "Not authenticated");
+}
+
+/**
+ * Authenticate a raw Bearer token against `ApiToken`.
+ * Annotates the Wide Event with `auth_method: "api_key"` and writes audit-log
+ * entries for both success and failure.
+ */
+async function authenticateBearer(
+  rawToken: string,
+  requiredPermission: string | undefined,
+): Promise<AuthContext> {
+  const tokenHashValue = hashToken(rawToken);
+
+  const apiToken = await prisma.apiToken.findUnique({
+    where: { tokenHash: tokenHashValue },
+    select: {
+      id: true,
+      userId: true,
+      permissions: true,
+      revoked: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!apiToken) {
+    auditLog("auth.bearer.failure", {
+      details: { reason: "unknown_token" },
+    }).catch(() => {});
+    throw new HttpError(401, "Invalid token");
+  }
+
+  if (apiToken.revoked) {
+    auditLog("auth.bearer.failure", {
+      userId: apiToken.userId,
+      details: { reason: "revoked", tokenId: apiToken.id },
+    }).catch(() => {});
+    throw new HttpError(401, "Invalid token");
+  }
+
+  if (apiToken.expiresAt && apiToken.expiresAt <= new Date()) {
+    auditLog("auth.bearer.failure", {
+      userId: apiToken.userId,
+      details: { reason: "expired", tokenId: apiToken.id },
+    }).catch(() => {});
+    throw new HttpError(401, "Token expired");
+  }
+
+  if (
+    requiredPermission &&
+    !apiToken.permissions.includes(requiredPermission)
+  ) {
+    auditLog("auth.bearer.failure", {
+      userId: apiToken.userId,
+      details: {
+        reason: "insufficient_permissions",
+        tokenId: apiToken.id,
+        required: requiredPermission,
+      },
+    }).catch(() => {});
+    throw new HttpError(403, "Insufficient permissions");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: apiToken.userId },
+  });
+
+  if (!user) {
+    auditLog("auth.bearer.failure", {
+      userId: apiToken.userId,
+      details: { reason: "user_missing", tokenId: apiToken.id },
+    }).catch(() => {});
+    throw new HttpError(401, "Invalid token");
+  }
+
+  // Fire-and-forget: refresh lastUsedAt without blocking the request.
+  prisma.apiToken
+    .update({
+      where: { id: apiToken.id },
+      data: { lastUsedAt: new Date() },
+    })
+    .catch(() => {});
+
+  auditLog("auth.bearer.success", {
+    userId: user.id,
+    details: { tokenId: apiToken.id },
+  }).catch(() => {});
+
+  const evt = getEvent();
+  if (evt) {
+    evt.setAuth({
+      user_id: user.id,
+      user_role: user.role,
+      auth_method: "bearer",
+    });
+  }
+
+  // Use the token expiry as the session expiry; fall back to a 30-day window if
+  // the token has no fixed expiry so the contract `{ expiresAt: Date }` holds.
+  const expiresAt =
+    apiToken.expiresAt ?? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+
+  return {
+    session: { id: apiToken.id, expiresAt },
+    user,
+  };
+}
+
+/**
+ * Require an authenticated admin user. Throws HttpError(401) or HttpError(403).
+ * Cookie-only — Bearer tokens never elevate to admin (security boundary).
  * Automatically annotates the Wide Event with auth context.
  */
-export async function requireAuth(): Promise<{
-  session: { id: string; expiresAt: Date };
-  user: Awaited<ReturnType<typeof getSession>> extends infer R
-    ? R extends { user: infer U }
-      ? U
-      : never
-    : never;
-}> {
+export async function requireAdmin(): Promise<AuthContext> {
   const sessionData = await getSession();
   if (!sessionData) throw new HttpError(401, "Not authenticated");
 
@@ -121,22 +285,6 @@ export async function requireAuth(): Promise<{
     });
   }
 
-  return sessionData;
-}
-
-/**
- * Require an authenticated admin user. Throws HttpError(401) or HttpError(403).
- * Automatically annotates the Wide Event with auth context.
- */
-export async function requireAdmin(): Promise<{
-  session: { id: string; expiresAt: Date };
-  user: Awaited<ReturnType<typeof getSession>> extends infer R
-    ? R extends { user: infer U }
-      ? U
-      : never
-    : never;
-}> {
-  const sessionData = await requireAuth();
   if (sessionData.user.role !== "ADMIN") {
     throw new HttpError(403, "Admin access required");
   }

--- a/src/lib/auth/issue-token.ts
+++ b/src/lib/auth/issue-token.ts
@@ -1,0 +1,75 @@
+/**
+ * Helper for issuing an `ApiToken` for a user — currently used by the
+ * native-client auto-login flow (login + passkey login-verify) so the iOS
+ * app can talk to bearer-protected routes without juggling the session
+ * cookie. The raw `hlk_<hex>` value is returned exactly once.
+ */
+import { randomBytes } from "node:crypto";
+import { prisma } from "@/lib/db";
+import { hashToken } from "@/lib/auth/hmac";
+
+export interface IssuedToken {
+  token: string;
+  expiresAt: Date;
+  tokenId: string;
+  name: string;
+}
+
+export interface IssueTokenOptions {
+  userId: string;
+  /** Token row name (also surfaced to the user under /api/tokens). */
+  name: string;
+  /** Default permissions. `["*"]` = unrestricted (matches cookie scope). */
+  permissions?: string[];
+  /** Lifetime in days. */
+  expiresInDays?: number;
+}
+
+/**
+ * Generate a new `hlk_<64 hex>` token, store its hash, and return the raw
+ * value to the caller. The plaintext token is never persisted and must
+ * never be logged.
+ */
+export async function issueApiToken(
+  opts: IssueTokenOptions,
+): Promise<IssuedToken> {
+  const rawToken = `hlk_${randomBytes(32).toString("hex")}`;
+  const tokenHashValue = hashToken(rawToken);
+  const expiresAt = new Date(
+    Date.now() + (opts.expiresInDays ?? 90) * 24 * 60 * 60 * 1000,
+  );
+
+  const created = await prisma.apiToken.create({
+    data: {
+      userId: opts.userId,
+      name: opts.name,
+      tokenHash: tokenHashValue,
+      permissions: opts.permissions ?? ["*"],
+      expiresAt,
+    },
+    select: { id: true },
+  });
+
+  return {
+    token: rawToken,
+    expiresAt,
+    tokenId: created.id,
+    name: opts.name,
+  };
+}
+
+/**
+ * Detect whether the request is from a native client and should receive a
+ * bearer token in the login response. Two opt-in signals:
+ *   - `X-Client-Type: native`
+ *   - `User-Agent: HealthLog-iOS/...`
+ */
+export function isNativeClientRequest(headers: Headers): boolean {
+  const xClient = headers.get("x-client-type");
+  if (xClient && xClient.toLowerCase() === "native") return true;
+
+  const ua = headers.get("user-agent") ?? "";
+  if (ua.startsWith("HealthLog-iOS")) return true;
+
+  return false;
+}

--- a/src/lib/auth/profile-update.ts
+++ b/src/lib/auth/profile-update.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared profile-update logic. The web client hits `/api/auth/profile` PUT
+ * and the iOS client hits `/api/user/profile` PATCH — both funnel through
+ * `applyProfileUpdate` so we don't fork the validation/audit path.
+ */
+import { prisma } from "@/lib/db";
+import { auditLog } from "@/lib/auth/audit";
+import { profileSchema } from "@/lib/validations/auth";
+import { z } from "zod/v4";
+
+const extendedProfileSchema = profileSchema.extend({
+  displayName: z.string().min(1).max(80).nullable().optional(),
+  locale: z.enum(["de", "en"]).nullable().optional(),
+  timezone: z.string().min(1).max(64).optional(),
+});
+
+export type ApplyProfileInput = z.infer<typeof extendedProfileSchema>;
+
+export interface ApplyProfileResult {
+  ok: true;
+  user: {
+    id: string;
+    username: string;
+    displayName: string | null;
+    email: string | null;
+    role: string;
+    heightCm: number | null;
+    dateOfBirth: Date | null;
+    gender: string | null;
+    timezone: string;
+    locale: string | null;
+  };
+}
+
+export interface ApplyProfileError {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+/**
+ * Validate and persist profile updates for `userId`. Returns either an
+ * `ApplyProfileResult` on success or `ApplyProfileError` with a status
+ * code so callers can shape the wire response themselves.
+ */
+export async function applyProfileUpdate(
+  userId: string,
+  body: unknown,
+  ipAddress?: string | null,
+): Promise<ApplyProfileResult | ApplyProfileError> {
+  const parsed = extendedProfileSchema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      status: 422,
+      message: parsed.error.issues[0]?.message ?? "Validation error",
+    };
+  }
+
+  const data = parsed.data;
+  const normalizedEmail = data.email ? data.email.trim().toLowerCase() : null;
+
+  if (data.email !== undefined && normalizedEmail) {
+    const existing = await prisma.user.findUnique({
+      where: { email: normalizedEmail },
+      select: { id: true },
+    });
+    if (existing && existing.id !== userId) {
+      return { ok: false, status: 409, message: "Email already in use" };
+    }
+  }
+
+  const updates: Record<string, unknown> = {};
+  if (data.email !== undefined) updates.email = normalizedEmail;
+  if (data.heightCm !== undefined) updates.heightCm = data.heightCm ?? null;
+  if (data.dateOfBirth !== undefined) {
+    updates.dateOfBirth = data.dateOfBirth ? new Date(data.dateOfBirth) : null;
+  }
+  if (data.gender !== undefined) updates.gender = data.gender;
+  if (data.displayName !== undefined) {
+    updates.displayName =
+      data.displayName === null || data.displayName === ""
+        ? null
+        : data.displayName.trim();
+  }
+  if (data.locale !== undefined) updates.locale = data.locale;
+  if (data.timezone !== undefined) updates.timezone = data.timezone;
+
+  const updatedUser = await prisma.user.update({
+    where: { id: userId },
+    data: updates,
+  });
+
+  await auditLog("profile.update", {
+    userId: updatedUser.id,
+    ipAddress: ipAddress ?? null,
+  });
+
+  return {
+    ok: true,
+    user: {
+      id: updatedUser.id,
+      username: updatedUser.username,
+      displayName: updatedUser.displayName,
+      email: updatedUser.email,
+      role: updatedUser.role,
+      heightCm: updatedUser.heightCm,
+      dateOfBirth: updatedUser.dateOfBirth,
+      gender: updatedUser.gender,
+      timezone: updatedUser.timezone,
+      locale: updatedUser.locale,
+    },
+  };
+}

--- a/src/lib/doctor-report-data.ts
+++ b/src/lib/doctor-report-data.ts
@@ -1,0 +1,269 @@
+/**
+ * Server-side aggregator for doctor-report data.
+ *
+ * Single source of truth for the aggregated payload consumed by both
+ * `/api/doctor-report` (JSON, client renders PDF) and
+ * `/api/doctor-report/pdf` (server-rendered PDF). Keeps the two endpoints
+ * structurally identical so visual parity between client- and server-rendered
+ * PDFs is guaranteed by construction, not by drift-prone copy-paste.
+ */
+
+import { prisma } from "@/lib/db";
+import {
+  getEffectiveRange,
+  type ThresholdOverridesJson,
+} from "@/lib/analytics/effective-range";
+import {
+  resolveGlucoseUnit,
+  thresholdMetricForContext,
+  type GlucoseUnit,
+} from "@/lib/glucose";
+import type { GlucoseContext } from "@/generated/prisma/client";
+
+export interface DoctorReportStats {
+  avg: number;
+  min: number;
+  max: number;
+  count: number;
+  latest: number;
+}
+
+export interface DoctorReportCompliance {
+  total: number;
+  taken: number;
+  skipped: number;
+  missed: number;
+}
+
+export interface DoctorReportMood {
+  avg: number;
+  min: number;
+  max: number;
+  count: number;
+  distribution: Record<number, number>;
+}
+
+export interface DoctorReportData {
+  period: { days: number; since: string };
+  patient: {
+    username: string | null;
+    dateOfBirth: string | null;
+    gender: string | null;
+    heightCm: number | null;
+  };
+  measurements: Record<string, Array<{ value: number; measuredAt: string }>>;
+  stats: Record<string, DoctorReportStats>;
+  glucoseStats: Record<string, DoctorReportStats>;
+  glucoseRanges: Record<string, { min: number; max: number }>;
+  glucoseUnit: GlucoseUnit;
+  bmi: number | null;
+  compliance: Record<string, DoctorReportCompliance>;
+  medications: Array<{
+    name: string;
+    dose: string;
+    schedules: Array<{
+      windowStart: string;
+      windowEnd: string;
+      label: string | null;
+    }>;
+  }>;
+  mood: DoctorReportMood | null;
+}
+
+const GLUCOSE_CONTEXTS: GlucoseContext[] = [
+  "FASTING",
+  "POSTPRANDIAL",
+  "RANDOM",
+  "BEDTIME",
+];
+
+/**
+ * Validate and normalise the requested reporting window.
+ * Accepts an unknown value (typically `body.days`); falls back to 90.
+ */
+export function normaliseDays(value: unknown, fallback = 90): number {
+  if (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 365
+  ) {
+    return value;
+  }
+  return fallback;
+}
+
+/**
+ * Aggregate the doctor-report payload for a user over the last `days` days.
+ * Pure data assembly — no auth, no rate-limit, no audit. Idempotent.
+ */
+export async function collectDoctorReportData(
+  userId: string,
+  days: number,
+): Promise<DoctorReportData> {
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+
+  const [measurements, medications, intakeEvents, moodEntries, userProfile] =
+    await Promise.all([
+      prisma.measurement.findMany({
+        where: { userId, measuredAt: { gte: since } },
+        orderBy: { measuredAt: "asc" },
+      }),
+      prisma.medication.findMany({
+        where: { userId, active: true },
+        include: { schedules: true },
+      }),
+      prisma.medicationIntakeEvent.findMany({
+        where: { userId, scheduledFor: { gte: since } },
+        include: { medication: { select: { name: true } } },
+        orderBy: { scheduledFor: "asc" },
+      }),
+      prisma.moodEntry.findMany({
+        where: { userId, moodLoggedAt: { gte: since } },
+        orderBy: { moodLoggedAt: "asc" },
+      }),
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          username: true,
+          dateOfBirth: true,
+          gender: true,
+          heightCm: true,
+          glucoseUnit: true,
+          thresholdsJson: true,
+        },
+      }),
+    ]);
+
+  // Group measurements by type.
+  const byType: Record<
+    string,
+    Array<{ value: number; measuredAt: string }>
+  > = {};
+  for (const m of measurements) {
+    if (!byType[m.type]) byType[m.type] = [];
+    byType[m.type].push({
+      value: m.value,
+      measuredAt: m.measuredAt.toISOString(),
+    });
+  }
+
+  // Per-type stats.
+  const stats: Record<string, DoctorReportStats> = {};
+  for (const [type, entries] of Object.entries(byType)) {
+    const values = entries.map((e) => e.value);
+    stats[type] = {
+      avg: values.reduce((a, b) => a + b, 0) / values.length,
+      min: Math.min(...values),
+      max: Math.max(...values),
+      count: values.length,
+      latest: values[values.length - 1],
+    };
+  }
+
+  // Medication compliance.
+  const compliance: Record<string, DoctorReportCompliance> = {};
+  for (const event of intakeEvents) {
+    const name = event.medication.name;
+    if (!compliance[name]) {
+      compliance[name] = { total: 0, taken: 0, skipped: 0, missed: 0 };
+    }
+    compliance[name].total++;
+    if (event.takenAt) {
+      compliance[name].taken++;
+    } else if (event.skipped) {
+      compliance[name].skipped++;
+    } else {
+      compliance[name].missed++;
+    }
+  }
+
+  // Mood summary.
+  const moodScores = moodEntries.map((e) => e.score);
+  const mood: DoctorReportMood | null =
+    moodScores.length > 0
+      ? {
+          avg: moodScores.reduce((a, b) => a + b, 0) / moodScores.length,
+          min: Math.min(...moodScores),
+          max: Math.max(...moodScores),
+          count: moodScores.length,
+          distribution: {
+            1: moodScores.filter((s) => s === 1).length,
+            2: moodScores.filter((s) => s === 2).length,
+            3: moodScores.filter((s) => s === 3).length,
+            4: moodScores.filter((s) => s === 4).length,
+            5: moodScores.filter((s) => s === 5).length,
+          },
+        }
+      : null;
+
+  // BMI from latest weight + profile height.
+  const weightStats = stats.WEIGHT;
+  const bmiRaw =
+    weightStats && userProfile?.heightCm
+      ? weightStats.latest / (userProfile.heightCm / 100) ** 2
+      : null;
+  const bmi = bmiRaw !== null ? Math.round(bmiRaw * 10) / 10 : null;
+
+  // Per-context glucose stats + effective ranges (canonical mg/dL).
+  const glucoseStats: Record<string, DoctorReportStats> = {};
+  const glucoseRanges: Record<string, { min: number; max: number }> = {};
+  const glucoseRows = measurements.filter((m) => m.type === "BLOOD_GLUCOSE");
+  const overrides = (userProfile?.thresholdsJson ??
+    null) as ThresholdOverridesJson | null;
+  const profileForRange = {
+    heightCm: userProfile?.heightCm ?? null,
+    dateOfBirth: userProfile?.dateOfBirth ?? null,
+    gender: userProfile?.gender ?? null,
+  };
+  for (const ctx of GLUCOSE_CONTEXTS) {
+    const rows = glucoseRows.filter((m) => m.glucoseContext === ctx);
+    if (rows.length === 0) continue;
+    const values = rows.map((r) => r.value);
+    glucoseStats[ctx] = {
+      avg: values.reduce((a, b) => a + b, 0) / values.length,
+      min: Math.min(...values),
+      max: Math.max(...values),
+      count: values.length,
+      latest: values[values.length - 1],
+    };
+    const eff = getEffectiveRange(
+      thresholdMetricForContext(ctx),
+      profileForRange,
+      overrides,
+    );
+    if (eff.range) {
+      glucoseRanges[ctx] = { min: eff.range.greenMin, max: eff.range.greenMax };
+    }
+  }
+
+  return {
+    period: { days, since: since.toISOString() },
+    patient: {
+      username: userProfile?.username ?? null,
+      dateOfBirth: userProfile?.dateOfBirth
+        ? userProfile.dateOfBirth.toISOString()
+        : null,
+      gender: userProfile?.gender ?? null,
+      heightCm: userProfile?.heightCm ?? null,
+    },
+    measurements: byType,
+    stats,
+    glucoseStats,
+    glucoseRanges,
+    glucoseUnit: resolveGlucoseUnit(userProfile?.glucoseUnit ?? null),
+    bmi,
+    compliance,
+    medications: medications.map((m) => ({
+      name: m.name,
+      dose: m.dose,
+      schedules: m.schedules.map((s) => ({
+        windowStart: s.windowStart,
+        windowEnd: s.windowEnd,
+        label: s.label,
+      })),
+    })),
+    mood,
+  };
+}

--- a/src/lib/doctor-report-pdf-core.ts
+++ b/src/lib/doctor-report-pdf-core.ts
@@ -1,0 +1,505 @@
+/**
+ * Isomorphic PDF renderer for the doctor report.
+ *
+ * Runs identically in the browser (settings page download) and in Node
+ * (server-rendered `/api/doctor-report/pdf` endpoint). All locale-sensitive
+ * strings and number/date formatting are driven by the injected
+ * `{ t, locale }` so DE and EN output match the user's UI language.
+ *
+ * jsPDF is fully isomorphic: `doc.output("arraybuffer")` returns a valid
+ * `%PDF-` byte stream in both environments.
+ */
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+import { makeFormatters } from "./format-locale";
+import type { Locale } from "./i18n/config";
+import { convertGlucose, resolveGlucoseUnit } from "./glucose";
+import type { DoctorReportData } from "./doctor-report-data";
+
+type T = (key: string, params?: Record<string, string | number>) => string;
+
+export interface DoctorReportRenderOptions {
+  t: T;
+  locale: Locale;
+  /**
+   * Optional fixed timestamp for "createdOn"/footer. Useful for deterministic
+   * tests; defaults to `new Date()`.
+   */
+  now?: Date;
+}
+
+const TYPE_LABEL_KEYS: Record<string, string> = {
+  WEIGHT: "doctorReport.typeWeight",
+  BLOOD_PRESSURE_SYS: "doctorReport.typeBpSys",
+  BLOOD_PRESSURE_DIA: "doctorReport.typeBpDia",
+  PULSE: "doctorReport.typePulse",
+  BODY_FAT: "doctorReport.typeBodyFat",
+  SLEEP_DURATION: "doctorReport.typeSleep",
+  ACTIVITY_STEPS: "doctorReport.typeSteps",
+};
+
+const TYPE_UNIT_KEYS: Record<string, string | null> = {
+  WEIGHT: "kg",
+  BLOOD_PRESSURE_SYS: "mmHg",
+  BLOOD_PRESSURE_DIA: "mmHg",
+  PULSE: "bpm",
+  BODY_FAT: "%",
+  SLEEP_DURATION: "h",
+  ACTIVITY_STEPS: null, // translated unit
+};
+
+const MOOD_LABEL_KEYS: Record<number, string> = {
+  1: "doctorReport.moodAwful",
+  2: "doctorReport.moodBad",
+  3: "doctorReport.moodNeutral",
+  4: "doctorReport.moodGood",
+  5: "doctorReport.moodGreat",
+};
+
+const GLUCOSE_LABEL_KEYS = {
+  FASTING: "doctorReport.typeGlucoseFasting",
+  POSTPRANDIAL: "doctorReport.typeGlucosePostprandial",
+  RANDOM: "doctorReport.typeGlucoseRandom",
+  BEDTIME: "doctorReport.typeGlucoseBedtime",
+} as const;
+
+const DEFAULT_GLUCOSE_RANGES = {
+  FASTING: { min: 70, max: 99 },
+  POSTPRANDIAL: { min: 70, max: 140 },
+  RANDOM: { min: 70, max: 140 },
+  BEDTIME: { min: 90, max: 150 },
+} as const;
+
+const GLUCOSE_CONTEXTS: Array<keyof typeof GLUCOSE_LABEL_KEYS> = [
+  "FASTING",
+  "POSTPRANDIAL",
+  "RANDOM",
+  "BEDTIME",
+];
+
+function getBmiClassificationKey(bmi: number): string {
+  if (bmi < 18.5) return "doctorReport.bmiUnderweight";
+  if (bmi < 25) return "doctorReport.bmiNormal";
+  if (bmi < 30) return "doctorReport.bmiOverweight";
+  if (bmi < 35) return "doctorReport.bmiObeseGrade1";
+  if (bmi < 40) return "doctorReport.bmiObeseGrade2";
+  return "doctorReport.bmiObeseGrade3";
+}
+
+function getBpClassificationKey(sys: number, dia: number): string {
+  if (sys < 120 && dia < 80) return "doctorReport.bpOptimal";
+  if (sys < 130 && dia < 85) return "doctorReport.bpNormal";
+  if (sys < 140 && dia < 90) return "doctorReport.bpHighNormal";
+  if (sys < 160 && dia < 100) return "doctorReport.bpHypertensionGrade1";
+  if (sys < 180 && dia < 110) return "doctorReport.bpHypertensionGrade2";
+  return "doctorReport.bpHypertensionGrade3";
+}
+
+/**
+ * Render the doctor report into a `jsPDF` instance.
+ *
+ * Used internally by both the client wrapper (which calls `.save()` on the
+ * returned doc) and the server renderer (which calls `.output("arraybuffer")`
+ * via `renderDoctorReportPdfBytes`).
+ */
+export function buildDoctorReportPdfDocument(
+  data: DoctorReportData,
+  options: DoctorReportRenderOptions,
+): jsPDF {
+  const { t, locale, now = new Date() } = options;
+  const formatters = makeFormatters(locale);
+  const num = (value: number, decimals = 1) =>
+    formatters.number(value, decimals);
+  const fmtDate = (iso: string) => formatters.date(iso);
+
+  const unitFor = (type: string): string => {
+    const staticUnit = TYPE_UNIT_KEYS[type];
+    if (staticUnit === null && type === "ACTIVITY_STEPS") {
+      return t("doctorReport.unitSteps");
+    }
+    return staticUnit ?? "";
+  };
+
+  const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const margin = 20;
+  let y = margin;
+
+  doc.setFontSize(22);
+  doc.setFont("helvetica", "bold");
+  doc.setTextColor(30, 30, 30);
+  doc.text(t("doctorReport.title"), margin, y);
+  y += 8;
+
+  doc.setFontSize(10);
+  doc.setFont("helvetica", "normal");
+  doc.setTextColor(100, 100, 100);
+  doc.text(t("doctorReport.subtitle"), margin, y);
+  y += 6;
+
+  doc.setDrawColor(200, 200, 200);
+  doc.setLineWidth(0.5);
+  doc.line(margin, y, pageWidth - margin, y);
+  y += 8;
+
+  doc.setFontSize(9);
+  doc.setTextColor(80, 80, 80);
+  const patientInfo: string[] = [];
+  if (data.patient.username) {
+    patientInfo.push(`${t("doctorReport.patient")}: ${data.patient.username}`);
+  }
+  if (data.patient.dateOfBirth) {
+    patientInfo.push(
+      `${t("doctorReport.dateOfBirth")}: ${fmtDate(data.patient.dateOfBirth)}`,
+    );
+  }
+  if (data.patient.gender) {
+    const genderKeys: Record<string, string> = {
+      MALE: "doctorReport.genderMale",
+      FEMALE: "doctorReport.genderFemale",
+    };
+    const genderKey =
+      genderKeys[data.patient.gender] ?? "doctorReport.genderOther";
+    patientInfo.push(`${t("doctorReport.gender")}: ${t(genderKey)}`);
+  }
+  if (data.patient.heightCm) {
+    patientInfo.push(
+      `${t("doctorReport.height")}: ${data.patient.heightCm} cm`,
+    );
+  }
+  patientInfo.push(
+    `${t("doctorReport.period")}: ${fmtDate(data.period.since)} — ${fmtDate(now.toISOString())}`,
+  );
+  patientInfo.push(
+    `${t("doctorReport.createdOn")}: ${fmtDate(now.toISOString())}`,
+  );
+
+  for (const line of patientInfo) {
+    doc.text(line, margin, y);
+    y += 4.5;
+  }
+  y += 4;
+
+  doc.setFontSize(14);
+  doc.setFont("helvetica", "bold");
+  doc.setTextColor(30, 30, 30);
+  doc.text(t("doctorReport.vitalsTitle"), margin, y);
+  y += 6;
+
+  const vitalRows: string[][] = [];
+  const vitalTypes = [
+    "WEIGHT",
+    "BLOOD_PRESSURE_SYS",
+    "BLOOD_PRESSURE_DIA",
+    "PULSE",
+    "BODY_FAT",
+  ];
+
+  for (const type of vitalTypes) {
+    const s = data.stats[type];
+    if (!s) continue;
+    const unit = unitFor(type);
+    vitalRows.push([
+      t(TYPE_LABEL_KEYS[type] ?? ""),
+      `${num(s.latest)} ${unit}`.trim(),
+      `${num(s.avg)} ${unit}`.trim(),
+      num(s.min),
+      num(s.max),
+      String(s.count),
+    ]);
+  }
+
+  // Per-context glucose rows. Values stored canonically in mg/dL — convert to
+  // the user's display unit. Reference ranges come from the server-side
+  // `getEffectiveRange()` (already baked into `data.glucoseRanges`).
+  const glucoseUnit = resolveGlucoseUnit(data.glucoseUnit ?? null);
+  for (const ctx of GLUCOSE_CONTEXTS) {
+    const s = data.glucoseStats?.[ctx];
+    if (!s) continue;
+    const conv = (v: number) => convertGlucose(v, glucoseUnit);
+    vitalRows.push([
+      t(GLUCOSE_LABEL_KEYS[ctx]),
+      `${num(conv(s.latest))} ${glucoseUnit}`.trim(),
+      `${num(conv(s.avg))} ${glucoseUnit}`.trim(),
+      num(conv(s.min)),
+      num(conv(s.max)),
+      String(s.count),
+    ]);
+  }
+
+  if (vitalRows.length > 0) {
+    autoTable(doc, {
+      startY: y,
+      head: [
+        [
+          t("doctorReport.colParameter"),
+          t("doctorReport.colCurrent"),
+          t("doctorReport.colAvgPeriod"),
+          t("doctorReport.colMin"),
+          t("doctorReport.colMax"),
+          t("doctorReport.colN"),
+        ],
+      ],
+      body: vitalRows,
+      theme: "grid",
+      styles: {
+        fontSize: 9,
+        cellPadding: 3,
+        textColor: [30, 30, 30],
+        lineColor: [200, 200, 200],
+        lineWidth: 0.3,
+      },
+      headStyles: {
+        fillColor: [245, 245, 245],
+        textColor: [30, 30, 30],
+        fontStyle: "bold",
+      },
+      alternateRowStyles: { fillColor: [252, 252, 252] },
+      margin: { left: margin, right: margin },
+    });
+    y =
+      (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable
+        .finalY + 8;
+  }
+
+  const sysStat = data.stats.BLOOD_PRESSURE_SYS;
+  const diaStat = data.stats.BLOOD_PRESSURE_DIA;
+  if (sysStat && diaStat) {
+    doc.setFontSize(12);
+    doc.setFont("helvetica", "bold");
+    doc.text(t("doctorReport.bpClassificationTitle"), margin, y);
+    y += 5;
+
+    doc.setFontSize(9);
+    doc.setFont("helvetica", "normal");
+    const bpClass = t(getBpClassificationKey(sysStat.avg, diaStat.avg));
+    doc.text(
+      `${t("doctorReport.avgBp")}: ${num(sysStat.avg, 0)}/${num(diaStat.avg, 0)} mmHg — ${t("doctorReport.classification")}: ${bpClass}`,
+      margin,
+      y,
+    );
+    y += 8;
+  }
+
+  if (data.bmi) {
+    doc.setFontSize(12);
+    doc.setFont("helvetica", "bold");
+    doc.text(t("doctorReport.bmiTitle"), margin, y);
+    y += 5;
+
+    doc.setFontSize(9);
+    doc.setFont("helvetica", "normal");
+    doc.text(
+      t("doctorReport.bmiRow", {
+        bmi: num(data.bmi, 1),
+        class: t(getBmiClassificationKey(data.bmi)),
+      }),
+      margin,
+      y,
+    );
+    y += 8;
+  }
+
+  // Glucose classification — one line per logged context.
+  const loggedGlucose = GLUCOSE_CONTEXTS.filter(
+    (ctx) => data.glucoseStats?.[ctx],
+  );
+  if (loggedGlucose.length > 0) {
+    if (y > 240) {
+      doc.addPage();
+      y = margin;
+    }
+    doc.setFontSize(12);
+    doc.setFont("helvetica", "bold");
+    doc.text(t("doctorReport.glucoseClassificationTitle"), margin, y);
+    y += 5;
+    doc.setFontSize(9);
+    doc.setFont("helvetica", "normal");
+    for (const ctx of loggedGlucose) {
+      const s = data.glucoseStats[ctx];
+      if (!s) continue;
+      const range = data.glucoseRanges?.[ctx] ?? DEFAULT_GLUCOSE_RANGES[ctx];
+      const conv = (v: number) => convertGlucose(v, glucoseUnit);
+      const inRange = s.avg >= range.min && s.avg <= range.max;
+      const classKey = inRange
+        ? "doctorReport.glucoseInTarget"
+        : s.avg < range.min
+          ? "doctorReport.glucoseBelowTarget"
+          : "doctorReport.glucoseAboveTarget";
+      doc.text(
+        t("doctorReport.glucoseRow", {
+          label: t(GLUCOSE_LABEL_KEYS[ctx]),
+          avg: num(conv(s.avg), 1),
+          unit: glucoseUnit,
+          rangeMin: num(conv(range.min)),
+          rangeMax: num(conv(range.max)),
+          class: t(classKey),
+        }),
+        margin,
+        y,
+      );
+      y += 5;
+    }
+    y += 3;
+  }
+
+  const complianceEntries = Object.entries(data.compliance);
+  if (complianceEntries.length > 0) {
+    if (y > 240) {
+      doc.addPage();
+      y = margin;
+    }
+
+    doc.setFontSize(14);
+    doc.setFont("helvetica", "bold");
+    doc.text(t("doctorReport.complianceTitle"), margin, y);
+    y += 6;
+
+    const compRows = complianceEntries.map(([name, c]) => {
+      const rate = c.total > 0 ? `${num((c.taken / c.total) * 100, 1)}%` : "—";
+      return [
+        name,
+        String(c.taken),
+        String(c.skipped),
+        String(c.missed),
+        String(c.total),
+        rate,
+      ];
+    });
+
+    autoTable(doc, {
+      startY: y,
+      head: [
+        [
+          t("doctorReport.colMedication"),
+          t("doctorReport.colTaken"),
+          t("doctorReport.colSkipped"),
+          t("doctorReport.colMissed"),
+          t("doctorReport.colTotal"),
+          t("doctorReport.colComplianceRate"),
+        ],
+      ],
+      body: compRows,
+      theme: "grid",
+      styles: {
+        fontSize: 9,
+        cellPadding: 3,
+        textColor: [30, 30, 30],
+        lineColor: [200, 200, 200],
+        lineWidth: 0.3,
+      },
+      headStyles: {
+        fillColor: [245, 245, 245],
+        textColor: [30, 30, 30],
+        fontStyle: "bold",
+      },
+      alternateRowStyles: { fillColor: [252, 252, 252] },
+      margin: { left: margin, right: margin },
+    });
+    y =
+      (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable
+        .finalY + 8;
+  }
+
+  if (data.mood) {
+    if (y > 240) {
+      doc.addPage();
+      y = margin;
+    }
+
+    doc.setFontSize(14);
+    doc.setFont("helvetica", "bold");
+    doc.text(t("doctorReport.moodTitle"), margin, y);
+    y += 6;
+
+    doc.setFontSize(9);
+    doc.setFont("helvetica", "normal");
+    doc.text(
+      t("doctorReport.moodSummary", {
+        avg: num(data.mood.avg, 1),
+        count: data.mood.count,
+        min: num(data.mood.min, 0),
+        max: num(data.mood.max, 0),
+      }),
+      margin,
+      y,
+    );
+    y += 6;
+
+    const distRows = Object.entries(data.mood.distribution).map(
+      ([score, count]) => [
+        t(MOOD_LABEL_KEYS[Number(score)] ?? "doctorReport.moodNeutral"),
+        String(count),
+        data.mood && data.mood.count > 0
+          ? `${num((count / data.mood.count) * 100, 1)}%`
+          : "0%",
+      ],
+    );
+
+    autoTable(doc, {
+      startY: y,
+      head: [
+        [
+          t("doctorReport.colMood"),
+          t("doctorReport.colCount"),
+          t("doctorReport.colShare"),
+        ],
+      ],
+      body: distRows,
+      theme: "grid",
+      styles: {
+        fontSize: 9,
+        cellPadding: 3,
+        textColor: [30, 30, 30],
+        lineColor: [200, 200, 200],
+        lineWidth: 0.3,
+      },
+      headStyles: {
+        fillColor: [245, 245, 245],
+        textColor: [30, 30, 30],
+        fontStyle: "bold",
+      },
+      margin: { left: margin, right: margin },
+    });
+    y =
+      (doc as jsPDF & { lastAutoTable: { finalY: number } }).lastAutoTable
+        .finalY + 8;
+  }
+
+  const addFooter = (pageDoc: jsPDF) => {
+    const pageHeight = pageDoc.internal.pageSize.getHeight();
+    pageDoc.setFontSize(7);
+    pageDoc.setFont("helvetica", "italic");
+    pageDoc.setTextColor(140, 140, 140);
+    pageDoc.text(t("doctorReport.footerDisclaimer1"), margin, pageHeight - 14);
+    pageDoc.text(t("doctorReport.footerDisclaimer2"), margin, pageHeight - 10);
+    pageDoc.text(
+      t("doctorReport.footerSource", {
+        timestamp: formatters.dateTime(now),
+      }),
+      margin,
+      pageHeight - 6,
+    );
+  };
+
+  const totalPages = doc.getNumberOfPages();
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+    addFooter(doc);
+  }
+
+  return doc;
+}
+
+/**
+ * Render the doctor report and return the PDF as a `Uint8Array`.
+ * Isomorphic — works in browser and Node.
+ */
+export function renderDoctorReportPdfBytes(
+  data: DoctorReportData,
+  options: DoctorReportRenderOptions,
+): Uint8Array {
+  const doc = buildDoctorReportPdfDocument(data, options);
+  const ab = doc.output("arraybuffer");
+  return new Uint8Array(ab);
+}

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -1,0 +1,151 @@
+/**
+ * Idempotency-Key support for write endpoints (POST/PUT/PATCH/DELETE).
+ *
+ * Mobile clients send `Idempotency-Key: <uuid>`. The first request runs
+ * the handler normally and the response (status + body) is cached. Any
+ * retry within the TTL (24h) for the same `(userId, key, method, path)`
+ * tuple returns the cached envelope as a 200 (carrying the original
+ * status inside the JSON if needed) — no second side-effect.
+ */
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { annotate } from "@/lib/logging/context";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const SUPPORTED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+const KEY_REGEX = /^[A-Za-z0-9_\-:.]{8,128}$/;
+
+export interface IdempotencyContext {
+  userId: string;
+  key: string;
+  method: string;
+  path: string;
+}
+
+function getIdempotencyKey(request: Request | NextRequest): string | null {
+  const raw = request.headers.get("idempotency-key");
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!KEY_REGEX.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Look up a cached response for a (userId, key, method, path) tuple.
+ * Returns the cached NextResponse or null.
+ */
+async function findCached(ctx: IdempotencyContext): Promise<NextResponse | null> {
+  const row = await prisma.idempotencyKey.findUnique({
+    where: {
+      userId_key_method_path: {
+        userId: ctx.userId,
+        key: ctx.key,
+        method: ctx.method,
+        path: ctx.path,
+      },
+    },
+  });
+
+  if (!row) return null;
+  if (row.expiresAt <= new Date()) {
+    // Stale — purge and fall through.
+    await prisma.idempotencyKey.delete({ where: { id: row.id } }).catch(() => {});
+    return null;
+  }
+
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(row.responseBody);
+  } catch {
+    parsed = null;
+  }
+
+  annotate({
+    action: { name: "idempotency.replay" },
+    meta: { method: ctx.method, path: ctx.path },
+  });
+
+  // Replay original status to keep client behaviour byte-identical.
+  return NextResponse.json(parsed, {
+    status: row.responseStatus,
+    headers: {
+      "X-Idempotent-Replay": "true",
+    },
+  });
+}
+
+async function persistCached(
+  ctx: IdempotencyContext,
+  response: Response,
+): Promise<void> {
+  const cloned = response.clone();
+  const body = await cloned.text().catch(() => "");
+
+  await prisma.idempotencyKey
+    .create({
+      data: {
+        userId: ctx.userId,
+        key: ctx.key,
+        method: ctx.method,
+        path: ctx.path,
+        responseStatus: response.status,
+        responseBody: body,
+        expiresAt: new Date(Date.now() + TTL_MS),
+      },
+    })
+    .catch(() => {
+      // Concurrent insert with the same key — the other writer wins.
+      // Ignore because a future replay will hit their cached value.
+    });
+}
+
+/**
+ * Wrap a write handler so a repeat call with the same `Idempotency-Key`
+ * (and same userId/method/path) returns the originally cached response.
+ *
+ * The wrapped handler is responsible for authentication itself — this
+ * helper only triggers for methods in {POST, PUT, PATCH, DELETE} and only
+ * once `userIdResolver` returns a non-null value.
+ *
+ * No-op when the header is missing or the value is malformed.
+ */
+export function withIdempotency<
+  Args extends [Request | NextRequest, ...unknown[]],
+>(
+  handler: (...args: Args) => Promise<Response>,
+  userIdResolver: (...args: Args) => Promise<string | null>,
+): (...args: Args) => Promise<Response> {
+  return async (...args: Args): Promise<Response> => {
+    const request = args[0];
+    if (!SUPPORTED_METHODS.has(request.method)) {
+      return handler(...args);
+    }
+
+    const key = getIdempotencyKey(request);
+    if (!key) return handler(...args);
+
+    const userId = await userIdResolver(...args);
+    if (!userId) return handler(...args);
+
+    const url = new URL(request.url);
+    const ctx: IdempotencyContext = {
+      userId,
+      key,
+      method: request.method,
+      path: url.pathname,
+    };
+
+    const cached = await findCached(ctx);
+    if (cached) return cached;
+
+    const response = await handler(...args);
+
+    // Persist regardless of status so error retries don't fork into
+    // two different responses (matches Stripe/Square semantics).
+    await persistCached(ctx, response);
+
+    return response;
+  };
+}

--- a/src/lib/idempotency.ts
+++ b/src/lib/idempotency.ts
@@ -79,9 +79,10 @@ async function findCached(ctx: IdempotencyContext): Promise<NextResponse | null>
 async function persistCached(
   ctx: IdempotencyContext,
   response: Response,
+  preReadBody?: string,
 ): Promise<void> {
-  const cloned = response.clone();
-  const body = await cloned.text().catch(() => "");
+  const body =
+    preReadBody ?? (await response.clone().text().catch(() => ""));
 
   await prisma.idempotencyKey
     .create({
@@ -142,9 +143,30 @@ export function withIdempotency<
 
     const response = await handler(...args);
 
-    // Persist regardless of status so error retries don't fork into
-    // two different responses (matches Stripe/Square semantics).
-    await persistCached(ctx, response);
+    // Cache only client-stable responses. Replaying a stale 401/403
+    // (token expired mid-flight) or a 5xx would lock the user into a
+    // bogus result for the TTL window. 4xx-validation responses are
+    // intentionally cached so the same broken request doesn't hit the
+    // DB twice — but auth/throttle/server faults must not poison.
+    const cachable =
+      response.status < 400 ||
+      (response.status >= 400 &&
+        response.status < 500 &&
+        response.status !== 401 &&
+        response.status !== 403 &&
+        response.status !== 408 &&
+        response.status !== 429);
+
+    if (cachable) {
+      // Defence-in-depth: never persist a body that carries a freshly-issued
+      // bearer token. Auth routes shouldn't be wrapped in withIdempotency to
+      // begin with, but if a future caller forgets, we refuse to leak.
+      const cloned = response.clone();
+      const text = await cloned.text();
+      if (!text.includes("hlk_")) {
+        await persistCached(ctx, response, text);
+      }
+    }
 
     return response;
   };

--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -51,7 +51,7 @@ export interface WideEvent {
   auth?: {
     user_id?: string;
     user_role?: string;
-    auth_method?: "session" | "api_key" | "cron_secret" | "telegram_webhook" | "webhook_secret";
+    auth_method?: "session" | "bearer" | "api_key" | "cron_secret" | "telegram_webhook" | "webhook_secret";
   };
 
   // Business-Daten (was wurde getan)


### PR DESCRIPTION
## Summary

Set of additive, non-user-facing API plumbing changes to make the existing HealthLog API consumable by headless clients (mobile, scripts, integrations) without forking the codebase.

**Nothing visible to existing PWA users.** Web client behaviour is unchanged in every endpoint touched.

## Commits (atomic, revertable individually)

1. `feat(auth)` — Bearer-token fallback in `requireAuth()` (cookie path remains primary)
2. `feat(doctor-report)` — server-rendered PDF endpoint, shares aggregation with existing JSON endpoint
3. `chore(db)` — migration `0023` (purely additive: 3 nullable user columns + 2 new tables)
4. `feat(api)` — generic `Idempotency-Key` header support on POST/mutations
5. `feat(auth)` — optional Bearer token issuance on login when `X-Client-Type: native` is set
6. `refactor(auth/profile)` — extract validation/persistence helper; existing PUT response shape preserved
7. `feat(api)` — 7 new aggregator/adapter endpoints (dashboard/summary, measurements/series, integrations/healthkit, devices, medications/intake, insights/cards, insights/correlations)
8. `feat(achievements)` — opt-in `?format=ios` query for translated flat array
9. `chore(api)` — OpenAPI 3.1 spec at `docs/api/openapi.yaml`

## Non-breaking guarantees

- Migration is additive only; no `ALTER COLUMN`, no backfill.
- All new endpoints are at new paths.
- All behavioural changes on existing endpoints are gated by opt-in headers/queries (`X-Client-Type`, `Idempotency-Key`, `?format=ios`).
- `requireAuth()` cookie path runs first and short-circuits before any new lookup.
- `requireAdmin()` stays cookie-only.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 278/278 passing (49 new tests added across 9 files)
- [x] `pnpm lint` — 0 errors (11 warnings, 7 pre-existing)
- [x] Migration `0023` reviewed: 3 nullable column adds + 2 new tables, no destructive ops
- [ ] Smoke-test on staging: existing web flows (login, measurement create, mood entry, achievements page) behave identically
- [ ] Apply migration to staging DB, verify `prisma migrate status` clean

## Rollout

Rolled out as quiet infrastructure work. No release notes, no announcement, no external comms — internal API surface only. Future native clients (or scripts) will pick this up on their own schedule.
