### PR TITLE
fix(db): backfill missing users.locale column as a migration

### DIFF
--- a/prisma/migrations/0025_user_locale_drift_fix/migration.sql
+++ b/prisma/migrations/0025_user_locale_drift_fix/migration.sql
@@ -1,0 +1,14 @@
+-- 0025_user_locale_drift_fix
+-- The `users.locale` column has been on `prisma/schema.prisma` since the
+-- locale-aware reminder work in v1.3 but never landed in the migration
+-- history (it must have been applied via `prisma db push` to dev / prod
+-- but not committed as a migration). The schema drift is invisible until
+-- a fresh database is built from migrations alone — at which point the
+-- Prisma client tries to read `users.locale` and Postgres reports
+-- `column users.locale does not exist`.
+--
+-- This migration backfills the column with `IF NOT EXISTS` so it is a
+-- safe no-op against any database that was kept in sync via `db push`,
+-- and a clean add against any environment built strictly from this
+-- migrations directory (CI test containers, fresh deploys, etc.).
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "locale" TEXT;


### PR DESCRIPTION
## Summary

`users.locale` has been on `schema.prisma` since the v1.3 locale-aware reminder work but never landed in the migration history — the column was applied via `prisma db push` to dev/prod and not committed as a migration. Any environment built strictly from `prisma/migrations/` (CI testcontainers, brand-new self-host installs, …) hits `column users.locale does not exist` the first time the Prisma client touches it.

The new migration is `ADD COLUMN IF NOT EXISTS \"locale\" TEXT`, which is a clean add on a fresh database and a safe no-op against any environment that was already kept in sync via `db push`.

Caught by the integration testcontainer harness in PR #137.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` 494 / 494 green
- [x] Migration runs cleanly against an empty Postgres (\`prisma migrate deploy\`)
- [x] Migration is idempotent on a database that already has the column