### PR TITLE
fix(medications): restore lint to 0 errors via useQuery refactor of API-endpoint dialog

### DIFF
--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/use-auth";
 import { useTranslations } from "@/lib/i18n/context";
@@ -485,47 +485,58 @@ function ApiEndpointDialog({
   onClose: () => void;
 }) {
   const { t } = useTranslations();
+  const queryClient = useQueryClient();
   type ExampleType = "curl" | "wget" | "fetch" | "powershell";
 
-  const [enabled, setEnabled] = useState(false);
-  const [activeTokenCount, setActiveTokenCount] = useState(0);
-  const [loadingStatus, setLoadingStatus] = useState(false);
+  const apiEndpointKey = ["medication-api-endpoint", medication?.id];
+
+  type ApiEndpointStatus = { enabled: boolean; activeTokenCount: number };
+
+  const {
+    data: status,
+    isFetching: loadingStatus,
+    refetch: refetchStatus,
+    error: statusError,
+  } = useQuery<ApiEndpointStatus>({
+    queryKey: apiEndpointKey,
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/medications/${medication!.id}/api-endpoint`,
+      );
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error || t("medications.statusLoadFailed"));
+      }
+      return {
+        enabled: json.data.enabled === true,
+        activeTokenCount: json.data.activeTokenCount ?? 0,
+      };
+    },
+    enabled: !!medication,
+    staleTime: 0,
+    gcTime: 0,
+  });
+
+  const enabled = status?.enabled ?? false;
+  const activeTokenCount = status?.activeTokenCount ?? 0;
+
   const [token, setToken] = useState<string | null>(null);
   const [toggling, setToggling] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
   const [exampleType, setExampleType] = useState<ExampleType>("curl");
 
+  const displayMsg =
+    msg ?? (statusError instanceof Error ? statusError.message : null);
+
   function handleClose() {
-    setEnabled(false);
-    setActiveTokenCount(0);
+    queryClient.removeQueries({ queryKey: apiEndpointKey });
     setToken(null);
     setMsg(null);
     setCopied(null);
     setExampleType("curl");
     onClose();
   }
-
-  const loadStatus = useCallback(async () => {
-    if (!medication) return;
-    setLoadingStatus(true);
-    setMsg(null);
-    try {
-      const res = await fetch(`/api/medications/${medication.id}/api-endpoint`);
-      if (res.ok) {
-        const json = await res.json();
-        setEnabled(json.data.enabled === true);
-        setActiveTokenCount(json.data.activeTokenCount ?? 0);
-      } else {
-        const json = await res.json();
-        setMsg(json.error || t("medications.statusLoadFailed"));
-      }
-    } catch {
-      setMsg(t("medications.statusLoadFailed"));
-    } finally {
-      setLoadingStatus(false);
-    }
-  }, [medication, t]);
 
   async function toggleEndpoint(nextEnabled: boolean) {
     if (!medication) return;
@@ -547,15 +558,16 @@ function ApiEndpointDialog({
         return;
       }
 
-      setEnabled(json.data.enabled === true);
-      if (typeof json.data.activeTokenCount === "number") {
-        setActiveTokenCount(json.data.activeTokenCount);
-      } else if (
-        !json.data.enabled &&
-        typeof json.data.revokedTokenCount === "number"
-      ) {
-        setActiveTokenCount(0);
-      }
+      const nextStatus: ApiEndpointStatus = {
+        enabled: json.data.enabled === true,
+        activeTokenCount:
+          typeof json.data.activeTokenCount === "number"
+            ? json.data.activeTokenCount
+            : !json.data.enabled
+              ? 0
+              : (status?.activeTokenCount ?? 0),
+      };
+      queryClient.setQueryData<ApiEndpointStatus>(apiEndpointKey, nextStatus);
 
       if (json.data.token) {
         setToken(json.data.token);
@@ -578,11 +590,6 @@ function ApiEndpointDialog({
     setCopied(key);
     setTimeout(() => setCopied(null), 2000);
   }
-
-  useEffect(() => {
-    if (!medication) return;
-    void loadStatus();
-  }, [medication, loadStatus]);
 
   const baseUrl =
     typeof window !== "undefined" ? window.location.origin : "https://...";
@@ -756,11 +763,11 @@ function ApiEndpointDialog({
             )}
           </div>
 
-          {msg && (
+          {displayMsg && (
             <p
-              className={`text-sm ${msg === t("medications.apiEndpointActivated") || msg === t("medications.apiEndpointDeactivated") ? "text-dracula-green" : "text-destructive"}`}
+              className={`text-sm ${displayMsg === t("medications.apiEndpointActivated") || displayMsg === t("medications.apiEndpointDeactivated") ? "text-dracula-green" : "text-destructive"}`}
             >
-              {msg}
+              {displayMsg}
             </p>
           )}
 
@@ -780,7 +787,7 @@ function ApiEndpointDialog({
               <DropdownMenuContent align="start">
                 <DropdownMenuItem
                   onClick={() => {
-                    void loadStatus();
+                    void refetchStatus();
                   }}
                   disabled={loadingStatus || toggling}
                 >


### PR DESCRIPTION
## Summary

The medications page's "API endpoint" dialog ran its initial status load through a `useCallback` + `useEffect` pair. Inside the callback, `setLoadingStatus(true)` fired synchronously before the first `await`, which the strict `react-hooks/set-state-in-effect` rule flags as a cascading-render risk. That was the last remaining ESLint error on `main` (1 error baseline since the v1.3.x cycle — the v1.4 settings monolith carried three more, all cleared by the A2-content extraction in #143).

This PR converts the dialog to TanStack Query — same fetch shape, but the effect disappears entirely.

## What changed

- `enabled` / `activeTokenCount` / `loadingStatus` now derive from a `useQuery({ queryKey: ["medication-api-endpoint", id], … })`.
- The "Reload status" menu item calls `refetch()`.
- After a successful toggle PUT, the response is written back through `queryClient.setQueryData` so the UI updates in place without a second GET.
- Status-fetch errors flow through the same callout that toggle errors do (`displayMsg = msg ?? statusError.message`).
- `gcTime: 0` + `removeQueries` on close keep the cache from leaking the active-token count between successive openings of the dialog.

No user-visible change. Same network calls, same UX.

## Quality gates

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 658/658 pass (no test removed/skipped)
- [x] `pnpm lint` — **0 errors** (12 warnings, all pre-existing unused-var hints)
- [x] `pnpm exec prettier --check` — clean
