### PR TITLE
hotfix: pin to GHCR :1.3.3 to rule out runtime regression

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,12 @@ services:
   # For horizontal scaling switch to the web/worker split below
   # (HEALTHLOG_PROCESS_TYPE=web on this service + uncomment app-worker).
   app:
-    image: ghcr.io/mbombeck/healthlog:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Pinned to GHCR :1.3.3 multi-arch image (gestern released, audit-tested).
+    # Production on apps-01 has been 503-ing since today's deploys; rolling back
+    # to the last release that's verifiably running on self-host installs to
+    # rule out runtime / Docker-network issues. No `build:` block on purpose:
+    # we want Coolify to PULL the prebuilt image, not build from source.
+    image: ghcr.io/mbombeck/healthlog:1.3.3
     container_name: healthlog-app
     ports:
       - "3000:3000"


### PR DESCRIPTION
Force-pull a known-good prebuilt image (yesterday's release). If it 503s identically, the apps-01 infra is the conclusive cause.