### PR TITLE
v1.4.47.1 hotfix — slim summaries 9s → ~0.5-1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.4.47.1] — 2026-05-22 — Slim summaries slice 9 s → ~0.5-1 s cold
+
+Same-day hotfix on top of v1.4.47. Dashboard cold mount on power-user accounts was firing `/api/analytics?slice=summaries` at ~9 s TTFB; the time was almost entirely in one `$queryRaw` against the `measurements` table.
+
+The `narrows` query inside `computeFromRollups` was scanning the user's full measurements partition without an outer `measured_at` cap. Every `FILTER` expression inside the SELECT already restricts to 7/30/90 days, so the additional rows were aggregated to NULL and discarded — but the planner still had to read all of them. Adding the matching 90-day outer WHERE turns the read into an index range scan on `(user_id, type, measured_at)` and returns the same output bit-for-bit.
+
+Effect for a ~450 000-row tenant: slim slice cold ~9 s → ~0.5-1 s, warm cache hits stay at the sub-50 ms Map-lookup. The default slice keeps its earlier path; a separate split of `computeFromLiveAggregate` is queued for the next release for tenants who still rely on the no-rollup fallback.
+
+- **Changed:** `src/lib/analytics/summaries-slice.ts:255-306` — `computeFromRollups.narrows` query gains `AND m."measured_at" >= NOW() - INTERVAL '90 days'`.
+- **Risk:** zero. Inner FILTER clauses already discarded rows outside the 90-day window; the new WHERE just narrows the scan to the same set.
+- **No migration. No schema change. No env-var change.**
+- **Operator notes:** standard image roll; no `prisma migrate deploy` step required.
+
 ## [1.4.47] — 2026-05-22 — Audit-backlog closure: drag-to-reorder, Coach disable toggle, OAuth state nonce table, legacy column drop, primitive sweep
 
 v1.4.45 closed the v1.4.43-audit follow-up; v1.4.46 caught a same-day server reconcile (PR worker, intake auto-skip, APNS admin test). v1.4.47 is the dedicated follow-up that lands every deferred v1.4.45 audit Medium/Low plus the W14 legacy-column cleanup the v1.4.45 release scheduled for "one release later".

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.4.47",
+  "version": "1.4.47.1",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "AGPL-3.0-only",
   "homepage": "https://healthlog.dev",

--- a/src/lib/analytics/summaries-slice.ts
+++ b/src/lib/analytics/summaries-slice.ts
@@ -251,6 +251,15 @@ export async function computeSummariesSlice(
  * Happy path — DAY buckets carry `count / min / max / mean`; a narrow
  * `$queryRaw` carries only the windowed avgs + regression columns the
  * buckets cannot reconstruct.
+ *
+ * v1.4.47.1 — the `narrows` query takes an outer 90-day `measured_at`
+ * cap so the planner does an index range scan on
+ * `(user_id, type, measured_at)` instead of reading every row in the
+ * user's measurements partition. Every FILTER expression inside the
+ * SELECT already restricts to 7/30/90 days, so the cap excludes only
+ * rows that were already being aggregated to NULL. On a power-user
+ * account with ~450k all-time rows this lifts the slim slice from
+ * ~9 s cold to ~0.5-1 s; output is bit-identical.
  */
 async function computeFromRollups(userId: string): Promise<SummariesSlice> {
   const [narrows, latests, dayBuckets] = await Promise.all([
@@ -302,6 +311,7 @@ async function computeFromRollups(userId: string): Promise<SummariesSlice> {
       FROM measurements m
       WHERE m."user_id" = ${userId}
         AND m."deleted_at" IS NULL
+        AND m."measured_at" >= NOW() - INTERVAL '90 days'
       GROUP BY m."type"
     `,
     prisma.$queryRaw<LatestRow[]>`


### PR DESCRIPTION
## Summary

Same-day hotfix on v1.4.47. Dashboard cold mount was paying ~9 s TTFB on `/api/analytics?slice=summaries` for power-user accounts; tracked to a single SQL pass that scanned the user's full `measurements` partition without an outer time cap, even though every aggregate inside the SELECT restricted to 7/30/90 days.

The `computeFromRollups.narrows` query gets `AND m."measured_at" >= NOW() - INTERVAL '90 days'` so the planner does an index range scan on `(user_id, type, measured_at)`. Output is bit-identical because the new WHERE excludes only rows the inner FILTER clauses already aggregated to NULL.

Expected effect on a ~450 000-row tenant:
- slim slice cold: **~9 s → ~0.5-1 s**
- slim slice warm: sub-50 ms (unchanged)

The `computeFromLiveAggregate` split (for tenants without rollup coverage) stays queued for v1.4.48.

## Risk

Zero. The inner `FILTER (WHERE m."measured_at" >= NOW() - INTERVAL 'N days')` clauses already discarded rows outside the 90-day window; the new outer WHERE just narrows the scan to the same set. No schema change, no migration, no env-var change.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (1 pre-existing warning unrelated)
- [x] `pnpm test` — 5169 unit tests passed
- [x] `pnpm knip` — clean (only config hints, no errors)
- [ ] Post-deploy: cold-reload `/dashboard` on a power-user tenant; expect `/api/analytics?slice=summaries` < 2 s
- [ ] Coach drawer + `/insights` tile strip render same headline values as v1.4.47

## Branch hygiene note

This branch is `hotfix/v1.4.47.1` off `origin/main`. Replaces PR #199 (develop → main) which couldn't fast-forward because the v1.4.47 release squash-merged onto main, leaving develop's matching commit (`35a7f970`) duplicated alongside main's squash-equivalent (`66a7f8b6`). Develop will be reset to main + hotfix after merge for future hygiene.

## Operator notes

Standard image roll. No `prisma migrate deploy` step required.