### PR TITLE
fix(docker): harden Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,30 +7,41 @@
 # compose `environment:` block at boot — `.env` should never ship.
 .env
 .env.*
-!.env.example
-!.env.production.example
+.env.example
+.env.production.example
 
 # Version control + CI metadata.
 .git
 .github
+.gitignore
 .gitleaks.toml
 
 # Build / install output that gets regenerated inside the builder stage.
 node_modules
 .next
 out
+dist
 coverage
 test-results
 playwright-report
+playwright/.cache
+playwright.config.ts
+vitest.config.mts
+vitest.integration.config.mts
+tests
+tests/
+e2e
+e2e/
 e2e-results
 .eslintcache
+eslint-plugins
+eslint-plugins/
+knip.json
 
-# Persisted session state from e2e runs.
-e2e/setup/storageState.json
-
-# Planning scratch + per-release audit notes (operator-local).
-.planning
-docs/audit
+# Generated local cache files
+*.tsbuildinfo
+next-env.d.ts
+public/sw-version.js
 
 # Captures from local debugging sessions.
 *.har
@@ -43,3 +54,34 @@ docs/audit
 .vscode
 .idea
 .DS_Store
+*.swp
+*.swo
+
+# Logs / Debug
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Docker compose / local ops files
+docker-compose*.yml
+compose*.yml
+Dockerfile
+.dockerignore
+
+# Documentation not needed for runtime image
+README.md
+CHANGELOG.md
+CLAUDE.md
+CONTRIBUTING.md
+CONTRIBUTING-AI.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+LICENSE.md
+LICENSE
+AGENTS.md
+.planning
+docs
+docs/*.md
+docs/**/*.md


### PR DESCRIPTION
<!-- Thanks for opening a PR. Please fill in the sections below. -->

## Summary

Extends .dockerignore to exclude local config, repository metadata, test files, documentation, editor artefacts and local Docker Compose files from the Docker build context.
This prevents unnecessary files from being copied into the builder stage and included in the final Next.js standalone image.

## Type of change

<!-- Tick all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [x] Test / CI / tooling
- [ ] Refactor (no functional change)

## Test plan

- [x] Built the image locally with `docker build --no-cache -t healthlog:dockerignore-test .`
- [x] Inspected the resulting runtime image and verified that the previously observed repository-only artefacts no longer appear under `/app`

## Screenshots (UI changes only)

Not applicable — no UI changes.

## Checklist

- [x] Targets the `develop` branch (not `main` — see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm lint` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm format:check` passes locally
- [x] `pnpm build` passes locally
- [x] User-facing strings go through `t("key")` with both `messages/en.json` and `messages/de.json` updated
- [x] No secrets, personal data, or maintainer-name references in committed files
- [ ] Updated `CHANGELOG.md` if user-visible
- [ ] Updated `docs/audit/` or `docs.healthlog.dev` if behavior or self-hosting docs change

## Linked issues

None.
<!-- Closes #123, Refs #456 -->
