### PR TITLE
release/v1.13.1 — wellness rings fill to the actual score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.13.1] — 2026-06-05 — wellness rings show the real score
+
+### Fixed
+
+- **The wellness-score rings now fill to the actual score.** Each ring was sweeping a full circle regardless of its value, so every score looked like 100%. The ring now fills proportionally — a 74 fills roughly three-quarters of the circle — across the overview tiles and the score detail view.
+
 ## [1.13.0] — 2026-06-05 — your own mood tags
 
 ### Added

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.13.0
+  version: 1.13.1
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "AGPL-3.0-only",
   "homepage": "https://healthlog.dev",

--- a/src/components/insights/derived/score-ring.tsx
+++ b/src/components/insights/derived/score-ring.tsx
@@ -2,6 +2,7 @@
 
 import {
   Label,
+  PolarAngleAxis,
   PolarRadiusAxis,
   RadialBar,
   RadialBarChart,
@@ -114,9 +115,12 @@ export function ScoreRing({
       })
     : t("insights.derived.scoreRing.ariaProvisional");
 
-  // RadialBar fills the arc proportionally to the bar's value against the
-  // PolarRadiusAxis [0,100] domain; the track spans a full clockwise circle
-  // from 12 o'clock, so a value of 74 fills 74% of the ring.
+  // The RadialBar's angular sweep is governed by the `<PolarAngleAxis>` number
+  // domain [0,100] below — NOT the PolarRadiusAxis (which positions the bar
+  // radially + anchors the centred number). Without the angle axis Recharts
+  // auto-scales the angular domain to the single datum, so every ring filled a
+  // full circle regardless of its score; pinning the domain makes a value of
+  // 74 sweep 74% of the track (full clockwise circle from 12 o'clock).
   const data = [{ name: "score", value: hasScore ? clamped : 0, fill }];
   const startAngle = 90;
   const endAngle = -270;
@@ -144,6 +148,14 @@ export function ScoreRing({
           outerRadius={outerRadius}
           barSize={dims.barSize}
         >
+          {/* Pins the value→angle scale so the bar sweeps `value`% of the
+              track instead of always filling the full circle. */}
+          <PolarAngleAxis
+            type="number"
+            domain={[0, 100]}
+            tick={false}
+            axisLine={false}
+          />
           <RadialBar
             dataKey="value"
             background={


### PR DESCRIPTION
The score-ring's RadialBar swept the full circle for any value — every wellness ring read as 100%. The angular domain was only pinned on `PolarRadiusAxis` (radius), so Recharts auto-scaled the angular sweep to the single datum. Add a `PolarAngleAxis` with a fixed `[0,100]` number domain so the bar sweeps value-percent of the track. Affects the overview wellness tiles + the score-anatomy detail view.

Gate: typecheck, lint, knip, 7461 unit (score-ring + anatomy tests green), build, openapi:check — all green.
