### PR TITLE
fix(docs): generate URL-safe Postgres passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@
 DATABASE_URL="postgresql://healthlog:CHANGE-ME@db:5432/healthlog?schema=public"
 
 # Postgres password — used both by the db service AND by DATABASE_URL above.
-# Pick a strong random password, e.g. `openssl rand -base64 24`.
+# Pick a strong random password, e.g. `openssl rand -hex 32`.
 POSTGRES_PASSWORD="CHANGE-ME"
 
 

--- a/.env.production.example
+++ b/.env.production.example
@@ -21,7 +21,7 @@
 # Core -- required for boot
 # -----------------------------------------------------------------------------
 DATABASE_URL="postgresql://healthlog:<password>@db:5432/healthlog?schema=public"
-POSTGRES_PASSWORD="<openssl rand -base64 24>"
+POSTGRES_PASSWORD="<openssl rand -hex 32>"
 NEXT_PUBLIC_APP_URL="https://healthlog.example.com"
 APP_URL="https://healthlog.example.com"
 ENCRYPTION_KEY="<openssl rand -hex 32>"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cp .env.example .env
 Edit `.env` and configure at minimum:
 
 ```
-POSTGRES_PASSWORD=<base64, 24 bytes>
+POSTGRES_PASSWORD=<hex, 32 bytes>
 DATABASE_URL="postgresql://healthlog:${POSTGRES_PASSWORD}@db:5432/healthlog"
 ENCRYPTION_KEY=<64-char hex>
 API_TOKEN_HMAC_KEY=<64-char hex>
@@ -29,7 +29,7 @@ API_TOKEN_HMAC_KEY=<64-char hex>
 Generate the three secrets:
 
 ```bash
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 24)" >> .env
+echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)" >> .env
 echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"       >> .env
 echo "API_TOKEN_HMAC_KEY=$(openssl rand -hex 32)"   >> .env
 ```

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cp .env.example .env
 Generate the three required secrets and paste them into `.env`:
 
 ```bash
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 24)" >> .env
+echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)" >> .env
 echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"       >> .env
 echo "API_TOKEN_HMAC_KEY=$(openssl rand -hex 32)"   >> .env
 ```

--- a/docs/self-hosting/getting-started.md
+++ b/docs/self-hosting/getting-started.md
@@ -38,7 +38,7 @@ HealthLog needs three secrets before it will boot. Generate them with
 `openssl` and append to `.env`:
 
 ```bash
-echo "POSTGRES_PASSWORD=$(openssl rand -base64 24)" >> .env
+echo "POSTGRES_PASSWORD=$(openssl rand -hex 32)" >> .env
 echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"       >> .env
 echo "API_TOKEN_HMAC_KEY=$(openssl rand -hex 32)"   >> .env
 ```

--- a/scripts/env-manifest.json
+++ b/scripts/env-manifest.json
@@ -15,7 +15,7 @@
         {
           "name": "POSTGRES_PASSWORD",
           "purpose": "Database password for the bundled `db` service in docker-compose.yml.",
-          "example": "<openssl rand -base64 24>"
+          "example": "<openssl rand -hex 32>"
         },
         {
           "name": "NEXT_PUBLIC_APP_URL",


### PR DESCRIPTION
<!-- Thanks for opening a PR. Please fill in the sections below. -->

## Summary

Replaces Base64-generated Postgres passwords with URL-safe hex passwords in the self-hosting setup instructions and environment templates.

Base64 output may contain URI-reserved characters such as `/`. Since `POSTGRES_PASSWORD` is interpolated unescaped into `DATABASE_URL`, affected generated passwords can break the database connection URL and prevent the app from connecting to the bundled Postgres service.

## Type of change

<!-- Tick all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only
- [ ] Test / CI / tooling
- [ ] Refactor (no functional change)

## Test plan

<!-- How was this verified? Manual steps, automated tests, screenshots for UI changes. -->

- [x] Verified that all documented `openssl rand -base64 24` examples were replaced with `openssl rand -hex 32`
- [x] Reviewed the resulting diff manually

## Screenshots (UI changes only)

Not applicable — no UI changes.

## Checklist

- [x] Targets the `develop` branch (not `main` — see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm lint` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm format:check` passes locally
- [ ] `pnpm build` passes locally
- [x] User-facing strings go through `t("key")` with both `messages/en.json` and `messages/de.json` updated
- [x] No secrets, personal data, or maintainer-name references in committed files
- [ ] Updated `CHANGELOG.md` if user-visible
- [x] Updated `docs/audit/` or `docs.healthlog.dev` if behavior or self-hosting docs change

## Linked issues

<!-- Closes #123, Refs #456 -->
