### PR TITLE
fix(docs): remove redundant NPM proxy directives

### DIFF
--- a/docs/self-hosting/reverse-proxy.md
+++ b/docs/self-hosting/reverse-proxy.md
@@ -97,15 +97,12 @@ In the NPM UI:
 6. **Advanced tab — Custom Nginx Configuration:**
 
    ```nginx
-   proxy_set_header X-Real-IP $remote_addr;
-   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   proxy_set_header X-Forwarded-Proto $scheme;
-   proxy_set_header Host $host;
-   proxy_http_version 1.1;
-   proxy_set_header Upgrade $http_upgrade;
-   proxy_set_header Connection "upgrade";
    proxy_read_timeout 300s;
    ```
+
+   Nginx Proxy Manager configures the standard forwarded headers
+   automatically and adds the WebSocket upgrade directives when
+   Websockets Support is enabled.
 
    The 300-second read timeout matters for long-running insight
    generations — anything shorter will cut streamed responses mid-flight.


### PR DESCRIPTION
<!-- Thanks for opening a PR. Please fill in the sections below. -->

## Summary

Simplifies the Nginx Proxy Manager example by removing proxy directives that NPM already configures automatically.

When **Websockets Support** is enabled, NPM already adds the WebSocket upgrade directives. Adding the same directives again in the Advanced configuration is redundant and caused the proxy host to stop working in a tested setup. NPM also sets the standard forwarded headers by default, so the Advanced configuration only needs the HealthLog-specific read timeout.

## Type of change

<!-- Tick all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation only
- [ ] Test / CI / tooling
- [ ] Refactor (no functional change)

## Test plan

<!-- How was this verified? Manual steps, automated tests, screenshots for UI changes. -->

* [x] Enabled **Websockets Support** in Nginx Proxy Manager and inspected the generated proxy-host configuration
* [x] Verified that NPM already adds `Upgrade`, `Connection`, and `proxy_http_version 1.1`
* [x] Reproduced a broken proxy host when the documented WebSocket directives were also added manually in the Advanced configuration
* [x] Verified that the proxy host works with only `proxy_read_timeout 300s;` in the Advanced configuration

## Screenshots (UI changes only)

Not applicable — documentation-only change.

## Checklist

- [x] Targets the `develop` branch (not `main` — see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm lint` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm format:check` passes locally
- [ ] `pnpm build` passes locally
- [x] User-facing strings go through `t("key")` with both `messages/en.json` and `messages/de.json` updated
- [x] No secrets, personal data, or maintainer-name references in committed files
- [ ] Updated `CHANGELOG.md` if user-visible
- [x] Updated `docs/audit/` or `docs.healthlog.dev` if behavior or self-hosting docs change

## Linked issues

<!-- Closes #123, Refs #456 -->
