### PR TITLE
release/v1.15.16 — wellness ring glow no longer clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.15.16] — 2026-06-07 — wellness ring glow no longer clipped
+
+### Fixed
+
+- **The score ring's glow shows in full.** On a wellness score detail page the ring's soft glow was being clipped at the card edge. The card no longer clips its contents (its background gradient still follows the rounded corners), so the glow renders uncut on every side.
+
 ## [1.15.15] — 2026-06-07 — one warm, motivating assistant voice
 
 ### Changed

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.15.15
+  version: 1.15.16
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.15.15",
+  "version": "1.15.16",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "AGPL-3.0-only",
   "homepage": "https://healthlog.dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -533,7 +533,12 @@
 .wellness-detail-card {
   --tile-hue: var(--dracula-purple);
   position: relative;
-  overflow: hidden;
+  /* The bottom-leaning gradient below is the card's OWN `background`, which is
+   * already clipped to `border-radius` — a painted background never bleeds past
+   * the rounded corners regardless of `overflow`. We deliberately do NOT set
+   * `overflow: hidden`: the ring's drop-shadow bloom (`.wellness-ring-arc`) is a
+   * CHILD box, and `overflow: hidden` would clip that glow at the card edge. The
+   * gradient stays corner-clipped; the glow renders uncut on all four sides. */
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--tile-hue) 16%, var(--card)) 0%,


### PR DESCRIPTION
Removes `overflow: hidden` from `.wellness-detail-card` so the score ring's drop-shadow glow renders uncut on all edges. The card's background gradient is a CSS background, so `border-radius` still clips it to the rounded corners without needing overflow clipping (the v1.15.12 QA flagged this exact interaction). One-line CSS fix; F1 hue tint + F3 gradient unchanged.