### PR TITLE
Release v1.27.21 — hero spacing and one green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.27.21] — 2026-07-07 — Hero spacing and one green
+
+### Changed
+
+- The dashboard hero's greeting anchors to the top edge instead of drifting to the vertical centre of the taller ring column, and the briefing follows closely instead of sitting a full step below — the wide gap under the greeting is gone.
+- A "green" score ring now uses the same green as every positive signal and trend delta beside it (the band-fallback ring green landed on its own hue before). Green reads as one green across rings, signals, and deltas — the change is app-wide (insights rings included), with computed contrast 11.9:1 dark / 6.1:1 light.
+
 ## [1.27.20] — 2026-07-07 — Coach and cycle toggle from the modules hub
 
 ### Changed

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.27.20
+  version: 1.27.21
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.27.20",
+  "version": "1.27.21",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.27.20";
+  /* @sw-version-fallback */ "v1.27.21";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -283,9 +283,11 @@
   --ring-strain-from: #e06aa8;
   --ring-strain-to: #ea74b1;
   --tile-strain: #ff79c6;
-  /* Band fallback (anatomy detail view, no per-metric hue). */
-  --ring-green-from: #3fb868;
-  --ring-green-to: #48c473;
+  /* Band fallback (anatomy detail view, no per-metric hue). Lands on the
+     app-wide --success green (#50fa7b) so a "green" ring matches the green
+     of every positive signal / trend delta beside it. */
+  --ring-green-from: #35d76a;
+  --ring-green-to: #50fa7b;
   --ring-yellow-from: #e0a050;
   --ring-yellow-to: #e8ab5c;
   --ring-red-from: #e0594a;
@@ -409,8 +411,10 @@
   --ring-strain-from: #b62478;
   --ring-strain-to: #bd2a7e;
   --tile-strain: #b0277d;
-  --ring-green-from: #138043;
-  --ring-green-to: #168a48;
+  /* Light: lands on the light-theme --success (#14720a) so ring green
+     matches every positive signal beside it. */
+  --ring-green-from: #12760f;
+  --ring-green-to: #14720a;
   --ring-yellow-from: #b27018;
   --ring-yellow-to: #bd7a1e;
   --ring-red-from: #b22e20;

--- a/src/components/dashboard/hero/dashboard-hero.tsx
+++ b/src/components/dashboard/hero/dashboard-hero.tsx
@@ -254,11 +254,13 @@ export function DashboardHero({
         "min-h-[8.75rem] p-4 md:min-h-[9.5rem] md:p-6",
       )}
     >
-      {/* Vertical rhythm: the section gap (greeting/ring row → briefing)
-          reads one step larger than the intra-block spacing so the two
-          zones separate cleanly; the card's own padding stays symmetric. */}
-      <div className="flex h-full flex-col gap-4 md:gap-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+      {/* Vertical rhythm: greeting/ring row and the briefing sit one
+          spacing step apart — tight enough that the briefing doesn't feel
+          adrift below a floating greeting. The top row aligns to its start
+          on desktop so the greeting anchors to the top edge instead of
+          drifting to the vertical centre of the taller ring column. */}
+      <div className="flex h-full flex-col gap-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0 flex-1 space-y-3">
             {/* Greeting leads the typographic hierarchy: larger + heavier
               than the verdict so the personalised line reads first.


### PR DESCRIPTION
Two dashboard-hero refinements from a live look:

- **Spacing** — the greeting anchored to the vertical centre of the taller ring column and the briefing sat a full step below it, leaving a wide gap under the greeting. The top row now aligns to its start (greeting anchors to the top edge) and the section gap tightens, so the briefing follows closely.
- **One green** — the band-fallback ring green used its own hue (#3fb868) while every positive signal and trend delta beside it used --success (#50fa7b), so two different greens sat next to each other. A green ring now lands on --success too — green reads as one green across rings, signals, and deltas. App-wide (insights rings included); computed contrast 11.9:1 dark / 6.1:1 light, well past the graphics floor.

Measured before/after at WQHD; maintainer approved the unified green. Gate: typecheck 0 · lint 0 · TZ=UTC tests 0 — 13,042 passing · prettier 0 · build 0 · knip 0 · bundle-check 0 · openapi in sync.