### PR TITLE
release/v1.28.47 — job queue engine update (pg-boss 12.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.28.47] — 2026-07-16 — Job queue engine update (pg-boss 12.26)
+
+Updates the background-job engine (pg-boss) from 12.20 to 12.26, which adds
+schema-drift detection, self-healing for background index builds, and a set of
+correctness fixes. Some of those fixes surface errors that earlier versions
+silently swallowed; the app already attaches an error listener to the queue and
+does not use the direct calls affected by the change, so the upgrade is
+transparent. No configuration change is needed.
+
 ## [1.28.46] — 2026-07-16 — Server performance on large instances
 
 Performance work for accounts with a lot of history, none of it changing what

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.28.46
+  version: 1.28.47
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.28.46",
+  "version": "1.28.47",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",
@@ -84,7 +84,7 @@
     "nodemailer": "9.0.3",
     "otpauth": "^9.5.1",
     "p-limit": "^7.3.0",
-    "pg-boss": "^12.20.0",
+    "pg-boss": "^12.26.0",
     "prisma": "^7.8.0",
     "qrcode": "^1.5.4",
     "radix-ui": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: ^7.3.0
         version: 7.3.0
       pg-boss:
-        specifier: ^12.20.0
-        version: 12.20.0
+        specifier: ^12.26.0
+        version: 12.26.0
       prisma:
         specifier: ^7.8.0
         version: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
@@ -3732,8 +3732,8 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
-  cron-parser@5.6.0:
-    resolution: {integrity: sha512-6159NDv4eDOjXYDmMTkvUtaVcIrNZI779ydTMOfDdi9fSjhPqmySx0icCHX2+nOyXgNSw6sFCsgLKxYs/2KPuQ==}
+  cron-parser@5.6.2:
+    resolution: {integrity: sha512-yJ/G1LVir6CnlkLI40CsampPLKl1SprGGlUagWtGJxewytRVYezv5xVyzzbT+Pvzx+VIRvZVF7/a0eEMTxdnTA==}
     engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
@@ -5568,8 +5568,8 @@ packages:
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
-  pg-boss@12.20.0:
-    resolution: {integrity: sha512-9YMoy8so5nXCzfCYwDfjW+3+nLPrcxRwSDrle8KMqqGDbS8jwzRN2ybT2dTHh8UnIvYtTHE2fFx2kOcTn3Pg3w==}
+  pg-boss@12.26.0:
+    resolution: {integrity: sha512-qMLyokiG2/Ey8U3sptl0We4nRGr1iveHL/lQ7g6n7cI/ubp9HVJZJnfPf6B9jzAbpd55uSdltKL/DMkyBC0ynw==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -6490,10 +6490,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-fest@5.7.0:
-    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
-    engines: {node: '>=20'}
 
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
@@ -10460,7 +10456,7 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  cron-parser@5.6.0:
+  cron-parser@5.6.2:
     dependencies:
       luxon: 3.7.2
 
@@ -12425,9 +12421,9 @@ snapshots:
   performance-now@2.1.0:
     optional: true
 
-  pg-boss@12.20.0:
+  pg-boss@12.26.0:
     dependencies:
-      cron-parser: 5.6.0
+      cron-parser: 5.6.2
       pg: 8.22.0
       serialize-error: 13.0.1
     transitivePeerDependencies:
@@ -13017,7 +13013,7 @@ snapshots:
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
-      type-fest: 5.7.0
+      type-fest: 5.8.0
 
   serve-static@2.2.1:
     dependencies:
@@ -13543,14 +13539,9 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.7.0:
-    dependencies:
-      tagged-tag: 1.0.0
-
   type-fest@5.8.0:
     dependencies:
       tagged-tag: 1.0.0
-    optional: true
 
   type-is@2.1.0:
     dependencies:

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.28.46";
+  /* @sw-version-fallback */ "v1.28.47";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Direct upgrade of the background-job engine (supersedes dependabot #479), shipped as its own isolated release with integration coverage.

pg-boss 12.20 → 12.26 adds schema-drift detection, self-healing background index builds, and correctness fixes — some of which surface errors that earlier versions silently swallowed (a documented behaviour change).

**Checked safe before shipping:**
- The app attaches an `error` listener to the boss instance (`reminder-worker.ts`) — the change's headline requirement.
- Call-site check: only `send`/`work`/`start`/`stop`/`schedule`/`on`/`getJobById`/`createQueue` are used — none of the direct `insert`/`fetch`/`deleteQueue` calls whose rejections the change now surfaces. The single `getJobById` (the v1.28.36 orphan-reconcile check) is already wrapped in try/catch.
- The full integration suite exercising the queue against real Postgres passes unchanged under 12.26.

typecheck, lint, unit tests, integration (real pg-boss/Postgres), build, openapi:check — green. No config change.
