### PR TITLE
release/v1.30.12 — index the dashboard medication reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.30.12] — 2026-07-18
+
+Faster medication reads.
+
+- **The dashboard's medication section stays fast as your log grows.** Its reads now use dedicated indexes instead of scanning the full intake history on every load, so a long history no longer slows down the daily view.
+
+No breaking changes.
+
 ## [1.30.11] — 2026-07-18
 
 Native single sign-on.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.30.11
+  version: 1.30.12
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.30.11",
+  "version": "1.30.12",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/prisma/migrations/0253_perf_medication_intake_indexes/migration.sql
+++ b/prisma/migrations/0253_perf_medication_intake_indexes/migration.sql
@@ -1,0 +1,11 @@
+-- v1.30.12 perf — index the two medication-intake read shapes the dashboard
+-- "meds today" builder fires that could not index-seek before: the sibling
+-- reads filtering (user_id, scheduled_for) without medication_id, and the
+-- per-medication last-taken group-by that scanned the whole intake history.
+-- Additive; no data change.
+
+-- CreateIndex
+CREATE INDEX "medication_intake_events_user_id_scheduled_for_idx" ON "medication_intake_events"("user_id", "scheduled_for");
+
+-- CreateIndex
+CREATE INDEX "medication_intake_events_user_id_medication_id_taken_at_idx" ON "medication_intake_events"("user_id", "medication_id", "taken_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2733,6 +2733,12 @@ model MedicationIntakeEvent {
   // v1.7.0 sync — keyset support for the `/api/sync/changes` intake feed
   // (`where userId` ordered by `(updatedAt asc, id asc)`).
   @@index([userId, updatedAt, id])
+  // v1.30.12 perf — the dashboard "meds today" read fires sibling queries that
+  // filter `(userId, scheduledFor)` WITHOUT `medicationId` (the composite above
+  // cannot range-seek those) and a per-medication `_max(takenAt)` group-by that
+  // scanned the whole intake history. These two let both index-seek instead.
+  @@index([userId, scheduledFor])
+  @@index([userId, medicationId, takenAt])
   @@map("medication_intake_events")
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.30.11";
+  /* @sw-version-fallback */ "v1.30.12";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
The first slice of the app-wide performance sweep (Fable's plan `.planning/research/2026-07-18-perf-sweep-plan.md`) — its top DB finding.

The dashboard "meds today" builder ran, on every load and every 120s poll, a per-medication `_max(takenAt)` group-by that scanned the account's **whole** medication-intake history, plus sibling reads filtering `(userId, scheduledFor)` that the existing `(userId, medicationId, scheduledFor)` composite couldn't range-seek. Both grew with account age.

- Two additive indexes (migration 0253, no data change, no behaviour change): `(user_id, scheduled_for)` and `(user_id, medication_id, taken_at)` — both reads now index-seek.

The behaviour-sensitive window-bound of the last-taken group-by, the RSC `cache()` memoization, and the per-route server-prefetch sweep are the remaining perf-plan tracks (deferred, they need care/measurement). Migration verified applying cleanly against Postgres locally; CI re-verifies via the integration suite.

Gate green. No breaking changes.
