### PR TITLE
chore: release v1.31.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.31.5] — 2026-07-21
+
+- **The production image no longer ships build-time package managers.** pnpm 11
+  verifies the lockfile under explicit build-script policy, npm and Corepack
+  are removed after migrations are prepared, and linked worktrees stay out of
+  local Docker build contexts.
+
+No migrations. No breaking changes.
+
 ## [1.31.4] — 2026-07-21
 
 - **Web and background processes now start and recover predictably.** Invalid
@@ -20,10 +29,6 @@
 - **Concurrent iOS registrations no longer fail intermittently.** Device and
   APNs notification-channel reconciliation now share one database lock and
   transaction, so simultaneous first registration remains idempotent.
-- **The production image no longer ships build-time package managers.** pnpm 11
-  verifies the lockfile under explicit build-script policy, npm and Corepack
-  are removed after migrations are prepared, and linked worktrees stay out of
-  local Docker build contexts.
 
 No migrations. No breaking changes.
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.31.4
+  version: 1.31.5
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.31.4",
+  "version": "1.31.5",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.31.4";
+  /* @sw-version-fallback */ "v1.31.5";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
## Summary
- bump the application and service-worker version to 1.31.5
- publish the runtime package-manager hardening under its own immutable patch release

## Verification
- release workflow contract tests
- formatting check
- TypeScript strict check