### PR TITLE
fix: restore runtime Prisma migration loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.31.6] — 2026-07-21
+
+- **The hardened runtime image can run database migrations again.** The
+  isolated Prisma CLI now exposes its pinned `dotenv` and `prisma/config`
+  dependencies to the copied production configuration while package managers
+  remain absent from the final image.
+
+No migrations. No breaking changes.
+
 ## [1.31.5] — 2026-07-21
 
 - **The production image no longer ships build-time package managers.** pnpm 11

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,14 +126,17 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
 COPY --from=builder /app/src/generated ./src/generated
 
-# Install the migration CLI plus a pinned launcher for the maintenance scripts
-# already shipped in the standalone tree. Then strip npm/Corepack and caches:
-# package managers are build-time tools, not runtime surface.
+# Install the migration CLI, its config dependency, and a pinned launcher for
+# the maintenance scripts already shipped in the standalone tree. The Prisma
+# config loads dotenv from /app, so expose the isolated copy there before
+# stripping npm/Corepack and their caches from the runtime surface.
 RUN mkdir -p /opt/prisma-cli && \
     cd /opt/prisma-cli && \
     npm init -y && \
-    npm install --omit=dev prisma@7.8 @prisma/engines@7.8 tsx@4.23.1 && \
+    npm install --omit=dev prisma@7.8 @prisma/engines@7.8 tsx@4.23.1 dotenv@17.4.2 && \
     ln -sfn /opt/prisma-cli/node_modules/.bin/tsx /usr/local/bin/healthlog-tsx && \
+    ln -sfn /opt/prisma-cli/node_modules/dotenv /app/node_modules/dotenv && \
+    ln -sfn /opt/prisma-cli/node_modules/prisma /app/node_modules/prisma && \
     rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/corepack /root/.cache/node/corepack /root/.npm && \
     rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack /usr/local/bin/pnpm /usr/local/bin/pnpx
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.31.5
+  version: 1.31.6
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.31.5",
+  "version": "1.31.6",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.31.5";
+  /* @sw-version-fallback */ "v1.31.6";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`

--- a/scripts/__tests__/release-workflows.test.ts
+++ b/scripts/__tests__/release-workflows.test.ts
@@ -249,6 +249,13 @@ describe("release container inputs", () => {
     expect(dockerfile).toContain(
       "ln -sfn /opt/prisma-cli/node_modules/.bin/tsx /usr/local/bin/healthlog-tsx",
     );
+    expect(dockerfile).toContain("dotenv@17.4.2");
+    expect(dockerfile).toContain(
+      "ln -sfn /opt/prisma-cli/node_modules/dotenv /app/node_modules/dotenv",
+    );
+    expect(dockerfile).toContain(
+      "ln -sfn /opt/prisma-cli/node_modules/prisma /app/node_modules/prisma",
+    );
   });
 
   it("keeps linked worktrees out of the Docker build context", () => {


### PR DESCRIPTION
## Summary

- expose pinned dotenv and Prisma config modules from the isolated runtime CLI
- preserve the package-manager-free production image
- add a release contract and prepare v1.31.6 metadata

## Verification

- exact production image built locally
- all 257 migrations applied from the image against fresh PostgreSQL
- entrypoint, health, and version smoke tests passed
- typecheck, lint, 16,393 unit tests, integration suite, OpenAPI, formatting, production build, and bundle budget passed
- Codex review found no regressions