### PR TITLE
fix: keep MCP lab search pages stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- **MCP search cursors keep lab results stable across pages.** Distinct analyte
+  names are ordered before offset pagination, preventing repeated or skipped
+  lab entries when a client follows `nextCursor`.
+
 ## [1.31.7] — 2026-07-20
 
 - **Current OpenAI reasoning models use their supported request contract.**

--- a/src/lib/mcp/__tests__/search-fetch.test.ts
+++ b/src/lib/mcp/__tests__/search-fetch.test.ts
@@ -120,6 +120,49 @@ describe("search", () => {
     expect(result.results.map((r) => r.id)).toContain("lab:LDL");
     expect(result.results.some((r) => r.id.startsWith("med:"))).toBe(false);
   });
+  it("keeps distinct lab analytes stable across cursor pages", async () => {
+    vi.mocked(buildCoachDataInventory).mockResolvedValue({
+      entries: [],
+      window: "90d",
+      restMode: false,
+      cycleEnabled: false,
+    } as never);
+    vi.mocked(prisma.medication.findMany).mockResolvedValue([]);
+
+    const analytes = Array.from({ length: 60 }, (_, index) => ({
+      analyte: `Analyte ${String(index).padStart(2, "0")}`,
+    }));
+    let callCount = 0;
+    vi.mocked(prisma.labResult.findMany).mockImplementation((args) => {
+      const ordered =
+        (args as { orderBy?: { analyte?: string } }).orderBy?.analyte === "asc";
+      const rows =
+        ordered || callCount++ % 2 === 0 ? analytes : [...analytes].reverse();
+      return Promise.resolve(rows) as ReturnType<
+        typeof prisma.labResult.findMany
+      >;
+    });
+
+    const def = tool("search");
+    const first = (await def.run(CTX, { query: "" })) as {
+      results: Array<{ id: string }>;
+      nextCursor?: string;
+    };
+    const second = (await def.run(CTX, {
+      query: "",
+      cursor: first.nextCursor,
+    })) as {
+      results: Array<{ id: string }>;
+    };
+
+    const labIds = [...first.results, ...second.results]
+      .map((result) => result.id)
+      .filter((id) => id.startsWith("lab:"));
+    expect(new Set(labIds)).toHaveLength(60);
+    expect(prisma.labResult.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { analyte: "asc" } }),
+    );
+  });
 });
 
 describe("fetch", () => {

--- a/src/lib/mcp/tools.ts
+++ b/src/lib/mcp/tools.ts
@@ -385,6 +385,7 @@ function searchAndFetchTools(): McpToolDefinition[] {
           where: { userId: ctx.userId, deletedAt: null },
           select: { analyte: true },
           distinct: ["analyte"],
+          orderBy: { analyte: "asc" },
           take: SEARCH_RESULT_SCAN_CAP,
         });
         for (const lab of labs) {


### PR DESCRIPTION
## What changed

MCP `search` rebuilt its lab result list without a database order. If PostgreSQL returned distinct analytes in a different order on the next request, the offset cursor could repeat some labs and skip others. The query now sorts analyte names before pagination.

The regression covers 60 analytes across two cursor pages and changes the simulated database order between requests unless the query asks for a stable order.

## Checks

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`: 16,441 passed, 12 skipped
- `pnpm test:integration`: 601 passed, 3 skipped
- `pnpm openapi:check`
- `pnpm format:check`
- `pnpm build`
- Codex review: no findings

Part of the v1.32 Task 11 correctness follow-up.