### PR TITLE
fix: honest health-score absence and a Coach safety false-positive

### DIFF
--- a/src/lib/ai/coach/__tests__/outbound-guard.test.ts
+++ b/src/lib/ai/coach/__tests__/outbound-guard.test.ts
@@ -67,6 +67,34 @@ describe("screenCoachReply — risk score", () => {
   });
 });
 
+// Issue #587 — a grounded Sleep Score explanation was replaced with the
+// generic clinical-risk refusal because the named-risk-engine pattern
+// matched bare "score", not just the SCORE2 risk calculator it was meant to
+// name.
+describe("screenCoachReply — issue #587 ordinary wellness-score wording", () => {
+  const allowed = [
+    "Your Sleep Score is based on sleep duration and stage balance — it's currently in a healthy range for you.",
+    "Your Readiness Score is lower than your recent baseline, likely from the shorter sleep window.",
+    "This Health Score is based on the available tracked pillars: BP, weight, mood, and compliance.",
+  ];
+  for (const reply of allowed) {
+    it(`allows: ${reply.slice(0, 40)}`, () => {
+      const d = screenCoachReply(reply, "en");
+      expect(d.block).toBe(false);
+      expect(d.reason).toBeNull();
+    });
+  }
+
+  it("still blocks a reply naming the SCORE2 risk engine", () => {
+    const d = screenCoachReply(
+      "Based on SCORE2, your cardiovascular risk profile looks elevated.",
+      "en",
+    );
+    expect(d.block).toBe(true);
+    expect(d.reason).toBe("risk_score");
+  });
+});
+
 describe("screenCoachReply — clean replies", () => {
   it("passes a grounded, non-prescriptive reply", () => {
     const reply =

--- a/src/lib/ai/safety/__tests__/outbound-screen.test.ts
+++ b/src/lib/ai/safety/__tests__/outbound-screen.test.ts
@@ -107,6 +107,54 @@ describe("screenModelOutput — risk-score, all six locales", () => {
   }
 });
 
+// ── issue #587 — bare "score" is not a fabricated clinical risk score ─────
+
+/**
+ * The named-risk-engine pattern used `score2?` (the `2` optional), so it
+ * matched bare "score" too — any mention of one of THIS APP's own computed,
+ * documented scores (Sleep Score, Readiness Score, Health Score, …) tripped
+ * the fabricated-risk-engine bank meant for SCORE2/Framingham/ASCVD/QRISK.
+ */
+const WELLNESS_SCORE_CLEAN: readonly string[] = [
+  "Your Sleep Score is based on sleep duration and stage balance.",
+  "Your Readiness Score is lower than your recent baseline.",
+  "This Health Score is based on the available tracked pillars.",
+  "Your Recovery Score and Stress Score both moved this week.",
+  "The Strain Score reflects yesterday's training load.",
+];
+
+describe("screenModelOutput — issue #587 ordinary wellness-score wording", () => {
+  for (const text of WELLNESS_SCORE_CLEAN) {
+    it(`passes: ${text}`, () => {
+      const d = screenModelOutput(text, "en", CONVERSATIONAL_CONTRACTS);
+      expect(d.block).toBe(false);
+      expect(d.reason).toBeNull();
+    });
+  }
+
+  it("still blocks the literal named risk engine SCORE2", () => {
+    const d = screenModelOutput(
+      "Based on SCORE2, your cardiovascular risk profile looks elevated.",
+      "en",
+      CONVERSATIONAL_CONTRACTS,
+    );
+    expect(d.block).toBe(true);
+    expect(d.reason).toBe("risk_score");
+  });
+
+  it("still blocks Framingham, ASCVD, and QRISK by name", () => {
+    for (const engine of [
+      "your Framingham result was concerning",
+      "the ASCVD estimate points to elevated risk",
+      "your QRISK figure came back high",
+    ]) {
+      const d = screenModelOutput(engine, "en", CONVERSATIONAL_CONTRACTS);
+      expect(d.block).toBe(true);
+      expect(d.reason).toBe("risk_score");
+    }
+  });
+});
+
 // ── causal claims (GROUND RULE 12) ───────────────────────────────────────
 
 const CAUSAL_VIOLATIONS: Record<Locale, string> = {

--- a/src/lib/ai/safety/outbound-screen.ts
+++ b/src/lib/ai/safety/outbound-screen.ts
@@ -215,8 +215,14 @@ const RISK_PATTERNS: Record<Locale, readonly RegExp[]> = {
     /\b\d{1,3}\s*%\s+(?:risk|chance|probability|likelihood)\b/i,
     /\b(?:risk|chance|probability|likelihood)\s+(?:of|is|at)\s+(?:about\s+|roughly\s+|~)?\d{1,3}\s*%/i,
     /\b(?:10[- ]year|ten[- ]year|lifetime)\s+(?:cardiovascular|cardiac|heart|stroke|mortality|cvd|ascvd)\s+risk\b/i,
-    // Named risk engines are fabrications on any surface — the server runs none.
-    /\b(?:framingham|ascvd|score2?|qrisk)\b/i,
+    // Named risk engines are fabrications on any surface — the server runs
+    // none. `score2?` (the `2` optional) was the #587 bug: it matched bare
+    // "score" too, so every mention of this app's OWN computed scores
+    // (Sleep Score, Readiness Score, Health Score, …) tripped the named-
+    // engine bank. SCORE2 is a specific clinical risk calculator (like
+    // Framingham/ASCVD/QRISK) — only the literal name is a fabrication
+    // signal; the bare word "score" carries none on its own.
+    /\b(?:framingham|ascvd|score2|qrisk)\b/i,
   ],
   de: [
     /\brisiko\s+(?:von|bei|liegt\s+bei)\s+(?:etwa\s+|ungefähr\s+|~)?\d{1,3}\s*%/i,

--- a/src/lib/analytics/__tests__/health-score-fast-path.test.ts
+++ b/src/lib/analytics/__tests__/health-score-fast-path.test.ts
@@ -444,6 +444,136 @@ describe("computeUserHealthScoreFastPath", () => {
     });
   });
 
+  /**
+   * Issue #582 — a raw-record-presence check let a `0`/red score through
+   * when every pillar still failed its own eligibility bar (weight needs
+   * >= 2 readings, mood needs >= 5 entries, BP needs a paired reading,
+   * compliance needs an active scheduled medication). The fix checks the
+   * COMPUTED result's components instead of raw row counts.
+   */
+  describe("insufficient-data guard (#582)", () => {
+    it("returns null — not a 0 score — when only one mood entry exists and no other pillar is eligible", async () => {
+      const coverage = new Map<string, boolean>([["WEIGHT", false]]);
+      FULLY_COVERED.mockReturnValue(false);
+      PROBE.mockResolvedValue(coverage);
+      const now = new Date("2026-06-07T12:00:00.000Z");
+
+      // No weight rows, no BP rows, no medications.
+      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([]).mockResolvedValueOnce(
+        [],
+      );
+      // Exactly one mood entry — below the 5-entry stability floor, so
+      // moodStability() resolves to null even though the raw row count
+      // is nonzero.
+      MOOD_FIND_MANY.mockResolvedValue([
+        { score: 4, moodLoggedAt: now },
+      ]);
+
+      const result = await computeUserHealthScoreFastPath({
+        userId: "user-one-mood-entry",
+        bpInTargetPct: null,
+        heightCm: null,
+        now,
+        coverage,
+      });
+
+      expect(result).toBeNull();
+      const calls = ANNOTATE.mock.calls.map((c) => c[0]);
+      const nullCall = calls.find(
+        (c) => c?.meta?.healthScore?.reason === "no_components_available",
+      );
+      expect(nullCall).toBeDefined();
+    });
+
+    it("returns null — not a 0 score — when only one weight reading exists and no other pillar is eligible", async () => {
+      const coverage = new Map<string, boolean>([["WEIGHT", false]]);
+      FULLY_COVERED.mockReturnValue(false);
+      PROBE.mockResolvedValue(coverage);
+      const now = new Date("2026-06-07T12:00:00.000Z");
+
+      // Exactly one weight reading — below the 2-reading regression floor,
+      // so weightTrendAlignment() resolves to null.
+      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([
+        {
+          measuredAt: new Date("2026-06-05T08:00:00.000Z"),
+          value: 82.5,
+          source: "MANUAL",
+        },
+      ]).mockResolvedValueOnce([]); // BP-SYS source attribution, empty.
+
+      const result = await computeUserHealthScoreFastPath({
+        userId: "user-one-weight-reading",
+        bpInTargetPct: null,
+        heightCm: null,
+        now,
+        coverage,
+      });
+
+      expect(result).toBeNull();
+      const calls = ANNOTATE.mock.calls.map((c) => c[0]);
+      const nullCall = calls.find(
+        (c) => c?.meta?.healthScore?.reason === "no_components_available",
+      );
+      expect(nullCall).toBeDefined();
+    });
+
+    it("returns null when raw records exist across multiple pillars but none clears its own minimum", async () => {
+      const coverage = new Map<string, boolean>([["WEIGHT", false]]);
+      FULLY_COVERED.mockReturnValue(false);
+      PROBE.mockResolvedValue(coverage);
+      const now = new Date("2026-06-07T12:00:00.000Z");
+
+      // One weight reading (< 2) + one mood entry (< 5) + no BP + no
+      // active medications. Every pillar has SOME data, but none is
+      // individually eligible.
+      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([
+        {
+          measuredAt: new Date("2026-06-05T08:00:00.000Z"),
+          value: 82.5,
+          source: "MANUAL",
+        },
+      ]).mockResolvedValueOnce([]);
+      MOOD_FIND_MANY.mockResolvedValue([{ score: 3, moodLoggedAt: now }]);
+
+      const result = await computeUserHealthScoreFastPath({
+        userId: "user-multi-pillar-ineligible",
+        bpInTargetPct: null,
+        heightCm: null,
+        now,
+        coverage,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("preserves a legitimately computed score of 0 rather than treating it as insufficient data", async () => {
+      const coverage = new Map<string, boolean>([["WEIGHT", false]]);
+      FULLY_COVERED.mockReturnValue(false);
+      PROBE.mockResolvedValue(coverage);
+      const now = new Date("2026-06-07T12:00:00.000Z");
+
+      // No weight, no mood, no medications — but a real, computed BP
+      // pillar that lands on exactly 0. This must stay a genuine `0`
+      // score, not get swept into the null branch.
+      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { measuredAt: new Date("2026-06-05T08:00:00.000Z"), source: "MANUAL" },
+      ]);
+
+      const result = await computeUserHealthScoreFastPath({
+        userId: "user-legit-zero",
+        bpInTargetPct: 0,
+        bpGradedScore: 0,
+        heightCm: null,
+        now,
+        coverage,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.components.bp.value).toBe(0);
+      expect(result?.score).toBe(0);
+    });
+  });
+
   describe("coverage probing", () => {
     it("probes coverage when the caller omits the map", async () => {
       const coverage = new Map<string, boolean>([]);

--- a/src/lib/analytics/__tests__/health-score-fast-path.test.ts
+++ b/src/lib/analytics/__tests__/health-score-fast-path.test.ts
@@ -459,15 +459,11 @@ describe("computeUserHealthScoreFastPath", () => {
       const now = new Date("2026-06-07T12:00:00.000Z");
 
       // No weight rows, no BP rows, no medications.
-      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([]).mockResolvedValueOnce(
-        [],
-      );
+      MEASUREMENT_FIND_MANY.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       // Exactly one mood entry — below the 5-entry stability floor, so
       // moodStability() resolves to null even though the raw row count
       // is nonzero.
-      MOOD_FIND_MANY.mockResolvedValue([
-        { score: 4, moodLoggedAt: now },
-      ]);
+      MOOD_FIND_MANY.mockResolvedValue([{ score: 4, moodLoggedAt: now }]);
 
       const result = await computeUserHealthScoreFastPath({
         userId: "user-one-mood-entry",

--- a/src/lib/analytics/health-score-fast-path.ts
+++ b/src/lib/analytics/health-score-fast-path.ts
@@ -465,33 +465,6 @@ export async function computeUserHealthScoreFastPath(
       score: r.score,
     }));
 
-  // Empty-path early-out — nothing computable, hero hides cleanly.
-  if (
-    bpInTargetPct === null &&
-    weightSeriesLast30d.length === 0 &&
-    moodSeriesLast30d.length === 0 &&
-    medicationCompliance30.length === 0
-  ) {
-    annotate({
-      meta: {
-        healthScore: {
-          score: null,
-          reason: "no_components_available",
-          path: weightCovered ? "rollup" : "live",
-          weightLongWindow:
-            weightLongWindowMean !== null
-              ? {
-                  mean: Math.round(weightLongWindowMean * 100) / 100,
-                  granularity: weightLongWindowGranularity,
-                  buckets: weightLongWindowBucketCount,
-                }
-              : null,
-        },
-      },
-    });
-    return null;
-  }
-
   const windowEndAt = now.toISOString();
 
   const bpSourceTokens = uniqueComponentSources(
@@ -557,6 +530,49 @@ export async function computeUserHealthScoreFastPath(
   };
 
   const result = computeHealthScore(current, previous);
+
+  // No-pillar-eligible early-out — nothing computable, hero hides cleanly.
+  //
+  // The naive raw-record check this replaced only asked whether any pillar
+  // had a nonzero row count, not whether that count cleared the pillar's own
+  // eligibility bar: weight needs >= 2 readings, mood needs >= 5 entries, BP
+  // needs a paired reading, compliance needs an active scheduled medication.
+  // An account that clears the row-count check but misses every pillar's
+  // bar (e.g. exactly one mood entry, or a single weight reading) fell
+  // through to `computeHealthScore`, which sums no components and returns a
+  // raw `0` — indistinguishable from a genuinely poor score. Checking the
+  // COMPUTED result's components (the same eligibility rules the score
+  // itself already applies) instead of re-deriving the thresholds here means
+  // this can never drift out of sync with `computeHealthScore`. A component
+  // that is legitimately computed as `0` still has `value: 0`, not `null`,
+  // so it is never swept into this branch.
+  const noComponentEligible =
+    result.components.bp.value === null &&
+    result.components.weight.value === null &&
+    result.components.mood.value === null &&
+    result.components.compliance.value === null;
+
+  if (noComponentEligible) {
+    annotate({
+      meta: {
+        healthScore: {
+          score: null,
+          reason: "no_components_available",
+          path: weightCovered ? "rollup" : "live",
+          weightLongWindow:
+            weightLongWindowMean !== null
+              ? {
+                  mean: Math.round(weightLongWindowMean * 100) / 100,
+                  granularity: weightLongWindowGranularity,
+                  buckets: weightLongWindowBucketCount,
+                }
+              : null,
+        },
+      },
+    });
+    return null;
+  }
+
   annotate({
     meta: {
       healthScore: {


### PR DESCRIPTION
## Summary

Two unrelated correctness fixes, both about the app showing something false rather than showing nothing.

- **#582** — the Personal Health Score fast-path checked raw record presence (any row at all across the four pillars) instead of each pillar's own eligibility bar — weight needs 2 readings, mood needs 5 entries, BP needs a paired reading, compliance needs an active scheduled medication. An account with some data but no pillar clearing its bar (one mood entry, one weight reading, …) fell through to `computeHealthScore`, which summed no components and returned a raw `0`/red score indistinguishable from a genuinely poor result. The guard now checks the COMPUTED result's own components instead of re-deriving the thresholds, so it can never drift out of sync with `computeHealthScore`. A pillar legitimately computed as `0` keeps its `0` value and is never swept into the null branch — verified with a dedicated regression test.

- **#587** — the outbound Coach safety screen's named-risk-engine pattern used `score2?` (the `2` optional), so it matched bare "score" too. Any mention of one of this app's own computed, documented scores (Sleep Score, Readiness Score, Health Score, Recovery Score, Stress Score, Strain Score) tripped the bank meant only to catch a fabricated named clinical-risk calculator (SCORE2, Framingham, ASCVD, QRISK), replacing a valid, correctly-grounded Coach answer with the generic clinical-risk refusal. Now requires the literal `SCORE2`. The other risk patterns — percentage-shaped risk claims and the three other named engines — are untouched, so a fabricated risk figure or a named risk-calculator claim still blocks.

## Test plan

- [x] Both bugs reproduced before the fix (mutation-checked: reverted the fix, confirmed the tests fail with the exact reported symptom, restored).
- [x] New regression tests added and passing; all pre-existing refusal / eligibility tests still pass.
- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm openapi:check && pnpm format:check && TZ=UTC pnpm test && pnpm build && pnpm bundle-check` — all green.

Closes #582, closes #587.