### PR TITLE
Give the evidence capture a budget that matches its work

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -651,12 +651,18 @@ const INSIGHTS_ROUTES: readonly RouteCase[] = [
   {
     name: "/insights overview",
     path: "/insights",
-    painted: (page) =>
-      page.locator('[data-slot="wellness-scores"]').filter({
-        has: page.locator(
-          '[data-slot="wellness-scores-grid"]:not([aria-busy="true"])',
-        ),
-      }),
+    // Wait for the page's own header region, not for the scores grid. The
+    // grid settling says nothing about whether the header has mounted, and
+    // the header is where this page's `<h1>` lives, so a scan gated on the
+    // grid can run against a page that has no heading yet and report a
+    // page-has-heading-one violation that is about timing rather than markup.
+    // That is how this case failed on a loaded mobile worker while desktop
+    // passed on the same tree.
+    //
+    // Deliberately the strip and not the `<h1>` inside it. Waiting for the
+    // heading itself would make axe's page-has-heading-one rule unable to
+    // fail here, which is worse than the flake it would hide.
+    painted: (page) => page.locator('[data-slot="insights-hero-strip"]'),
   },
   {
     name: "/insights/weight metric subpage",

--- a/e2e/v1341-ui-evidence.spec.ts
+++ b/e2e/v1341-ui-evidence.spec.ts
@@ -65,6 +65,18 @@ test.describe("v1.34.1 deterministic UI evidence", () => {
   test("captures the five release-review surfaces", async ({
     page,
   }, testInfo) => {
+    // Five full page loads and five captures in one case, deliberately: the
+    // evidence set is only comparable if every shot comes from one consistent
+    // state, so splitting it into five cases would defeat its purpose. That is
+    // five times the work of an ordinary case against the same default budget,
+    // and it timed out twice on loaded runners while passing everywhere else.
+    //
+    // This raises the wall-clock allowance to match the work, and nothing else.
+    // Every capture still has to happen and still has to succeed; no assertion
+    // is relaxed. If this case starts timing out again, the honest reading is a
+    // real slowdown in one of the five surfaces, not a budget to raise further.
+    test.slow();
+
     await mkdir(EVIDENCE_DIR, { recursive: true });
 
     await page.setViewportSize({ width: 1440, height: 900 });


### PR DESCRIPTION
The evidence case loads five surfaces and captures five shots against the default per-case timeout. It timed out twice tonight on loaded runners with the identical signature, and passed on every other run. That is the signature of a budget set for an ordinary case rather than for one doing five times the work.

The five stay in one case on purpose: the shots are only comparable if they come from one consistent state. So the allowance moves, not the structure.

No assertion is relaxed. Every capture still has to happen and still has to succeed. A future timeout here should be read as a real slowdown in one of the five surfaces rather than as a budget to raise again, and that reading is written into the file.