### PR TITLE
Scan the painted page, and bound the waits that could not time out

### DIFF
--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -664,12 +664,21 @@ const INSIGHTS_ROUTES: readonly RouteCase[] = [
     painted: (page) => page.locator(".recharts-wrapper").first(),
   },
   {
+    // The two states this page's OWN render produces: the list, or the
+    // no-workouts empty state. Never `[role="status"]`, because the busy
+    // skeletons carry it too (`chart-skeleton` in the streamed route shell is
+    // one), so that selector matched the loading tree the server sends before
+    // the page client has mounted anything. On a loaded runner the scan then
+    // landed on a document whose only heading had not rendered yet and blamed
+    // the app for a missing `<h1>` it does have. Same rule as the overview
+    // case above: a sentinel must prove the content, not the placeholder
+    // standing in for it.
     name: "/insights/workouts list",
     path: "/insights/workouts",
     painted: (page) =>
       page
         .locator(
-          '#main-content [data-slot="workout-list"], #main-content [role="status"]',
+          '#main-content [data-slot="workout-list"], #main-content [data-slot="empty-state"]',
         )
         .first(),
   },
@@ -679,9 +688,13 @@ const INSIGHTS_ROUTES: readonly RouteCase[] = [
     painted: (page) => page.locator('[data-slot="workout-detail-header"]'),
   },
   {
+    // `coach-page` is the sizing wrapper around a `<Suspense fallback={null}>`,
+    // so it is on screen while the conversation below it is still nothing at
+    // all. Gate on the conversation surface itself.
     name: "/coach",
     path: "/coach",
-    painted: (page) => page.locator('[data-slot="coach-page"]').first(),
+    painted: (page) =>
+      page.locator('[data-slot="coach-conversation"][data-variant="page"]'),
   },
 ];
 

--- a/e2e/utils/settle.ts
+++ b/e2e/utils/settle.ts
@@ -1,6 +1,24 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
 /**
+ * How long either settle wait in `settleBeforeMeasure` may take before the
+ * spec moves on.
+ *
+ * Both of those waits are written to end on their own terms; neither was
+ * bounded, and neither inherits a bound from anywhere, because the config
+ * leaves `actionTimeout` and `navigationTimeout` unset and Playwright reads
+ * that as "no limit". One request that never completes therefore ends the
+ * whole test instead of just the wait, and it ends it in the least useful way
+ * available: the run reports whichever call was still pending when the fixture
+ * tore the page down, so the message names a `page.evaluate` against a closed
+ * target rather than the surface that stalled. Six seconds is an order of
+ * magnitude above the slowest settle measured anywhere in this suite. Past
+ * that it is a stall, and a stall belongs in front of the spec's own
+ * assertions, which can say what is actually wrong.
+ */
+const SETTLE_BUDGET_MS = 6_000;
+
+/**
  * Gate a one-shot DOM read on the element it is about to measure.
  *
  * The failure this exists to prevent: a spec navigates with
@@ -45,6 +63,30 @@ export async function settleBeforeMeasure(
     .catch(() => {});
   // Fonts and late CSS change geometry after the element is visible, and
   // every measurement in this suite is geometric.
-  await page.waitForLoadState("networkidle").catch(() => {});
-  await page.evaluate(() => document.fonts?.ready);
+  await page
+    .waitForLoadState("networkidle", { timeout: SETTLE_BUDGET_MS })
+    .catch(() => {});
+  await waitForFonts(page);
+}
+
+/**
+ * Wait for webfonts to settle, bounded inside the page.
+ *
+ * `document.fonts.ready` belongs to the document, so awaiting it from a
+ * `page.evaluate` hands the test an unbounded wait on a promise no timeout
+ * reaches. Race it against a timer in the page instead, so a font that never
+ * arrives costs this wait and nothing else.
+ */
+export async function waitForFonts(
+  page: Page,
+  timeout = SETTLE_BUDGET_MS,
+): Promise<void> {
+  await page.evaluate(async (budget: number) => {
+    const ready = document.fonts?.ready;
+    if (!ready) return;
+    await Promise.race([
+      ready,
+      new Promise((resolve) => window.setTimeout(resolve, budget)),
+    ]);
+  }, timeout);
 }

--- a/e2e/v1341-ui-evidence.spec.ts
+++ b/e2e/v1341-ui-evidence.spec.ts
@@ -11,7 +11,7 @@ import {
   mockDashboardSnapshot,
 } from "./utils/mock-dashboard-snapshot";
 import { mockPopulatedInsights } from "./utils/mock-populated-insights";
-import { settleBeforeMeasure } from "./utils/settle";
+import { settleBeforeMeasure, waitForFonts } from "./utils/settle";
 
 const EVIDENCE_DIR = join(process.cwd(), "test-results", "v1341");
 
@@ -46,7 +46,9 @@ async function settleAndCapture(
     content:
       "*,*::before,*::after{animation:none!important;transition:none!important;caret-color:transparent!important}",
   });
-  await page.evaluate(() => document.fonts?.ready);
+  // The injected stylesheet can pull a font the page had not needed yet, so
+  // the wait repeats after it. Bounded, for the reason `waitForFonts` gives.
+  await waitForFonts(page);
   const path = join(EVIDENCE_DIR, filename);
   await page.screenshot({ path, animations: "disabled" });
   await testInfo.attach(filename, { path, contentType: "image/png" });


### PR DESCRIPTION
Two e2e failures, two different mechanisms, neither of which is what the symptom suggested.

**The accessibility scan waited on the skeleton.** The failing route was `/insights/workouts`, and its sentinel was `#main-content [role="status"]`. That role is not a content marker: the busy chart skeletons carry it too. A frame trace under 20x CPU throttle puts the sentinel at 408ms and the page's own `<h1>` at 4119ms, so axe running anywhere in that 3.7 second window correctly reports that the page has no level-one heading. `/coach` has the same shape at 241ms wide. The `/insights` overview has no gap at all, which is why moving its sentinel changed nothing.

Both routes now wait on a content marker, the same rule the overview case already applied. Deliberately not on the heading itself: waiting for an `<h1>` before asserting one exists would make that rule unable to fail. Removing the `<h1>` from the shell, the coach hero and the conversation title turns the matrix red with four violations per theme, and the new sentinels still do not wait for a heading.

**The evidence capture could not be rescued by a bigger budget.** `settleBeforeMeasure` ends with an unbounded `waitForLoadState("networkidle")` whose rejection is swallowed, followed by an unbounded `page.evaluate(() => document.fonts?.ready)`. The config sets no action or navigation timeout, so neither inherits a bound. Stalling one font request reproduces the reported signature exactly, including the misleading `Target page, context or browser has been closed` at the next evaluate rather than at the stall. Both waits are bounded now, and the same stalled run reaches the spec's real assertion in 12.4 seconds.

**Stated plainly:** the capture timeout was not reproduced at native speed, so this is a diagnosability fix for it, not a proven one. If it stalls again it will fail at an assertion that can name the surface instead of at a closed target. Which resource stalls on CI is still unknown, and the light/dark asymmetry is unexplained; both are written down rather than guessed at.