### PR TITLE
release/v1.35.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [1.35.6] — 2026-08-02
+
+### Fixed
+
+- The line under the top bar and the line under the sidebar header now meet.
+  They were one pixel apart, because the two carried the same height but painted
+  their border on different elements. Both now take height and border from one
+  place, so they cannot come apart again without a check failing.
+
+### Internal
+
+- A resolver that worked out a headline verdict for the dashboard is gone. Its
+  consumer was removed a while ago and it was never wired to anything else, so
+  it had been computing an answer nobody read. Every signal it covered already
+  has a live owner elsewhere.
+- Two waits in the browser-test helper could never time out, which turned a
+  stalled asset into a confusing error at the following step instead of a clear
+  one at the stall. They are bounded now.
+- A browser check waited for a marker that the loading placeholders also carry,
+  so it could inspect a page that had not finished arriving and report a problem
+  that was not there. It waits for real content now.
+
 ## [1.35.5] — 2026-08-02
 
 ### Fixed

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.35.5
+  version: 1.35.6
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.35.5",
+  "version": "1.35.6",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.35.5";
+  /* @sw-version-fallback */ "v1.35.6";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
The line under the top bar and the line under the sidebar header were one pixel apart. Both carried the same height; the step came from painting the border on different elements, so one band was 64 pixels with the line at 63 and the other 65 with the line at 64. Height and border now come from one place, and a check fails at exactly one pixel if they come apart again.

Also in: a resolver that had been computing a dashboard verdict nobody read since its consumer was retired, and two browser-test corrections whose absence produced misleading failures rather than useful ones.