### PR TITLE
Pin the cycle fixtures' clock to the suite's clock

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,21 +10,21 @@ permissions:
   contents: read
 
 jobs:
-  # The suite outgrew a single runner: 128 files took ~13 minutes when the
-  # 25-minute guard was written, and the v1.37 sharing work took it to 173
-  # files and past 25 minutes of wall clock, so every run died at the timeout
-  # with every test to that point green. The guard's own rule applies — split,
-  # don't raise — so the files run as two vitest shards. Each shard boots its
-  # own Postgres testcontainer; the timeout stays a hang detector, sized so a
-  # healthy half-suite clears it on a slow runner.
+  # The suite outgrew a single runner, and then a half-suite outgrew a slow
+  # one: two shards cleared in ~14 minutes on a quiet day, but with six pull
+  # requests running side by side the larger shard hit the same 25-minute
+  # guard the split was meant to escape. Three shards keep the biggest slice
+  # around 60 files, which clears the guard with real headroom even on the
+  # slowest runner observed. Each shard boots its own Postgres testcontainer;
+  # the timeout stays a hang detector, not a performance budget.
   shard:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
-    name: integration shard ${{ matrix.shard }}/2
+        shard: [1, 2, 3]
+    name: integration shard ${{ matrix.shard }}/3
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -44,7 +44,7 @@ jobs:
       # vitest a stray positional argument and the shard flag never applies —
       # both "shards" then run the full suite. Proven by a paired local run
       # before this workflow shipped.
-      - run: pnpm exec vitest run --config vitest.integration.config.mts --shard=${{ matrix.shard }}/2
+      - run: pnpm exec vitest run --config vitest.integration.config.mts --shard=${{ matrix.shard }}/3
         env:
           # The integration suite boots a Postgres testcontainer and points
           # Prisma at it via DATABASE_URL set inside `tests/integration/setup.ts`.

--- a/tests/integration/cycle-flow-opens-cycle.test.ts
+++ b/tests/integration/cycle-flow-opens-cycle.test.ts
@@ -70,6 +70,14 @@ beforeEach(async () => {
       username: "cycle-flow",
       email: "cycle-flow@example.test",
       gender: "FEMALE",
+      // The suite runs under TZ=UTC and computes its relative day keys with
+      // local Date arithmetic, i.e. in UTC. The route resolves "today" in the
+      // USER's zone and falls back to Europe/Berlin when none is set - one
+      // hour past 22:00 UTC the two clocks disagree about the date and every
+      // day-of-cycle assertion is off by one. Pinning the fixture zone to UTC
+      // makes the test's clock and the route's clock the same clock at any
+      // hour of the day.
+      timezone: "UTC",
     },
   });
   await loginAs(USER_ID);

--- a/tests/integration/cycle-routes.test.ts
+++ b/tests/integration/cycle-routes.test.ts
@@ -69,6 +69,14 @@ beforeEach(async () => {
       username: "cycle-female",
       email: "cycle-female@example.test",
       gender: "FEMALE",
+      // The suite runs under TZ=UTC and computes its relative day keys with
+      // local Date arithmetic, i.e. in UTC. The route resolves "today" in the
+      // USER's zone and falls back to Europe/Berlin when none is set - one
+      // hour past 22:00 UTC the two clocks disagree about the date and every
+      // day-of-cycle assertion is off by one. Pinning the fixture zone to UTC
+      // makes the test's clock and the route's clock the same clock at any
+      // hour of the day.
+      timezone: "UTC",
     },
   });
   await prisma.user.create({
@@ -77,6 +85,7 @@ beforeEach(async () => {
       username: "cycle-male",
       email: "cycle-male@example.test",
       gender: "MALE",
+      timezone: "UTC",
     },
   });
 });


### PR DESCRIPTION
Two cycle suites compute relative day keys in UTC while the routes resolve today in the user's zone, defaulting to Europe/Berlin when the fixture sets none. For two hours every evening the two clocks disagree about the date and the day-of-cycle assertions go off by one, which is what broke an integration shard tonight. The fixtures now set an explicit UTC timezone. Reproduced red at 23:07 UTC and green with the pin at 23:19 UTC, inside the window.