### PR TITLE
Drop the coach launch button from the workout detail

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Erholung",
     "workouts": {
       "title": "Workouts",
-      "askWhy": "Warum?",
-      "askWhyPrompt": "Warum ist diese Einheit so ausgefallen? Erkläre mir meine eigenen Werte dazu.",
       "description": "Letzte Läufe, Touren, Spaziergänge und Krafteinheiten — quellenübergreifend entdoppelt zwischen Apple Watch und Withings.",
       "emptyState": {
         "title": "Noch keine Workouts",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Recovery",
     "workouts": {
       "title": "Workouts",
-      "askWhy": "Ask why",
-      "askWhyPrompt": "Why did this session read the way it did? Walk me through my own numbers from it.",
       "description": "Recent runs, rides, walks and strength sessions, deduped across Apple Watch and Withings sources.",
       "emptyState": {
         "title": "No workouts yet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Recuperación",
     "workouts": {
       "title": "Entrenamientos",
-      "askWhy": "Por qué",
-      "askWhyPrompt": "¿Por qué salió así esta sesión? Explícame mis propios datos de ella.",
       "description": "Carreras, salidas en bici, paseos y sesiones de fuerza recientes, deduplicados entre Apple Watch y Withings.",
       "emptyState": {
         "title": "Aún no hay entrenamientos",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Récupération",
     "workouts": {
       "title": "Entraînements",
-      "askWhy": "Pourquoi",
-      "askWhyPrompt": "Pourquoi cette séance s'est-elle passée ainsi ? Explique-moi mes propres chiffres.",
       "description": "Courses, sorties à vélo, marches et séances de musculation récentes, dédupliquées entre Apple Watch et Withings.",
       "emptyState": {
         "title": "Aucun entraînement",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Recupero",
     "workouts": {
       "title": "Allenamenti",
-      "askWhy": "Perché",
-      "askWhyPrompt": "Perché questa sessione è andata così? Spiegami i miei dati di questa sessione.",
       "description": "Corse, uscite in bici, camminate e sessioni di forza recenti, deduplicati tra Apple Watch e Withings.",
       "emptyState": {
         "title": "Nessun allenamento",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -3120,8 +3120,6 @@
     "navRecovery": "Regeneracja",
     "workouts": {
       "title": "Treningi",
-      "askWhy": "Dlaczego",
-      "askWhyPrompt": "Dlaczego ta sesja wypadła w ten sposób? Wyjaśnij mi moje własne wyniki.",
       "description": "Ostatnie biegi, jazdy, marsze i treningi siłowe — zdeduplikowane między Apple Watch a Withings.",
       "emptyState": {
         "title": "Brak treningów",

--- a/src/app/insights/workouts/[id]/page.tsx
+++ b/src/app/insights/workouts/[id]/page.tsx
@@ -9,7 +9,6 @@ import { useTranslations } from "@/lib/i18n/context";
 import { useWorkoutDetail } from "@/hooks/use-workouts";
 import { useModulePageGuard } from "@/hooks/use-module-page-guard";
 import { BackLink } from "@/components/ui/back-link";
-import { CoachLaunchButton } from "@/components/insights/coach-launch-button";
 import { SubPageShell } from "@/components/insights/sub-page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 import { QueryErrorCard } from "@/components/ui/query-error-card";
@@ -31,7 +30,7 @@ import {
  * Layout, top to bottom (mobile-first single column):
  *   hero header → reserved Activity-Insight seam (renders nothing today)
  *   → stats grid + sport-average line → HR curve → effort zones → GPS
- *   route → per-km splits → "that day" → coach launch.
+ *   route → per-km splits → "that day".
  *
  * "That day" answers the last question the page is for: what the rest of
  * the day looked like around the session. It renders the day's own pulse
@@ -40,8 +39,8 @@ import {
  *
  * Every data-less section returns `null` (hide, don't render empty), so
  * an aggregates-only workout (a Strava ride with no wearable, a manual
- * entry) reads as hero + stats + "that day" + coach — compact but
- * honest, no empty shells.
+ * entry) reads as hero + stats + "that day" — compact but honest, no
+ * empty shells.
  *
  * Data flows from `GET /api/workouts/{id}?compact=1` (v1.4.32 + the #67
  * enrichment fields). The `canonicalId` pointer still resolves a
@@ -120,18 +119,6 @@ export default function InsightsWorkoutDetailPage({
           <WorkoutDetailRoute workout={data} />
           <WorkoutDetailSplits workout={data} />
           <WorkoutDetailDayContext workout={data} />
-          {/* 2026-07-17 UX-flows audit F6-1 — `workouts` narrows the
-              snapshot the first coach turn reads. v1.31.0 — `workoutId` pins
-              THIS session's own numbers as one additional snapshot section, so
-              the answer is about this workout rather than about training in
-              general, and the opener auto-sends so it lands directly. */}
-          <CoachLaunchButton
-            scope={{ metric: "workouts" }}
-            workoutId={data.id}
-            label={t("insights.workouts.askWhy")}
-            prefill={t("insights.workouts.askWhyPrompt")}
-            autoSend
-          />
         </>
       )}
     </SubPageShell>


### PR DESCRIPTION
The workout detail ended on a "Why?" button that opened the coach with a prefilled question about the session. It leaves on the maintainer's call. The import, the layout comment and the two locale strings go with it; no other call site used them. i18n guards green (53), typecheck clean, prettier clean.