### PR TITLE
Drop the two visit exports nothing consumes yet

### DIFF
--- a/src/lib/encounters/service.ts
+++ b/src/lib/encounters/service.ts
@@ -26,14 +26,6 @@ import {
 
 const DEFAULT_TIMEZONE = "Europe/Berlin";
 
-export async function resolveTimezone(userId: string): Promise<string> {
-  const row = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { timezone: true },
-  });
-  return row?.timezone || DEFAULT_TIMEZONE;
-}
-
 /**
  * The record owner's zone AND language, read together.
  *

--- a/src/lib/query-keys/index.ts
+++ b/src/lib/query-keys/index.ts
@@ -239,20 +239,6 @@ export const medicationDependentKeys = [
 export const cycleDependentKeys = [queryKeys.cycle(), queryKeys.insightsRoot()];
 
 /**
- * Keys invalidated when a visit or an address-book entry changes.
- *
- * Both roots ride together in one bundle rather than two, because the two
- * writes reach each other: renaming a practice changes the label every visit
- * that names it renders, and deleting one nulls the reference on visits that
- * stay. A bundle that evicted only the surface being written would leave the
- * other showing the pre-write name.
- */
-export const encounterDependentKeys = [
-  queryKeys.encounters(),
-  queryKeys.practitioners(),
-];
-
-/**
  * Invalidate every key in the bundle in parallel. Use this from mutation
  * `onSuccess` handlers so the call site stays a one-liner instead of repeating
  * `Promise.all(keys.map(...))` everywhere.


### PR DESCRIPTION
The visit stage shipped resolveTimezone and encounterDependentKeys ahead of their consumers; knip went red on the trunk with the merge, which blocks every open pull request's dead-code gate. Both leave now and return with the surfaces that call them, which is what the two-ended rule asks. DEFAULT_TIMEZONE stays, it has a live reader. typecheck clean, knip exit 0.