### PR TITLE
chore(release): v1.37.3 — the immunization record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [1.37.3] — 2026-08-09
+
+### Added
+
+- An immunization record. A new Vaccinations module, switched on under Settings then Modules, keeps a lifetime Impfpass. Each dose sits under the disease it protects against, with its place in the series worked out on the server, so a combination shot appears under every component it covers. You add a dose by picking from a catalogue of around thirty entries, searched by disease or antigen name, or by typing it the way your pass reads; a date plus one of those two is all that is required, and the lot number, the injection site, the practice, a link to a visit and an encrypted note are each optional. Where the catalogue knows a schedule it shows it with its source, as information rather than advice. A dose that carries a booster interval offers a prefilled reminder you can edit or decline, and confirming it writes an ordinary preventive-care reminder that appears on the checkups page and moves itself forward when you log the next dose. A vaccination scan in the document vault can attach to its record, the record can link documents it already holds, and the doctor report gains an immunization section you can leave out. The module rides the record-sharing model, so a parent can keep a child's Impfpass under a managed profile. Six languages throughout, including the catalogue names, and never a brand name.
 
 ### Fixed
 
@@ -24,6 +28,8 @@
   one already made for you.
 - The write and manage descriptions on the invite form are one line each now,
   with the full detail behind the info icon instead of a wall of text.
+- A preventive-care reminder set to the longest interval the engine allows no longer loses its next date when a dose is logged against it. The reminder now moves a full cycle forward instead of falling silent.
+- The catalogue and practice pickers now carry a name for a screen reader; a control that only showed an icon was unnamed before.
 
 ## [1.37.2] — 2026-08-08
 
@@ -52,6 +58,8 @@
   single figure, and it names which of the things you recorded weighed most on
   that day. It describes a connection between things you wrote down. It never
   claims a cause.
+
+  The rework this reading sits on grew from a concept Kai worked out in detail. Thanks, Kai.
 
   Below fifteen days there is nothing at all. Between fifteen and thirty the
   page says how far along it is instead of guessing. Between thirty and sixty

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.37.2
+  version: 1.37.3
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.37.2",
+  "version": "1.37.3",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.37.1";
+  /* @sw-version-fallback */ "v1.37.3";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`

--- a/src/app/vaccinations/page.tsx
+++ b/src/app/vaccinations/page.tsx
@@ -9,7 +9,7 @@ import { PageAuthGate } from "@/components/ui/page-auth-gate";
 import { VaccinationsView } from "@/components/vaccinations/vaccinations-view";
 
 /**
- * v1.38.0 — the immunization log entry.
+ * v1.37.3: the immunization log entry.
  *
  * Gated on the resolved `modules.vaccinations` flag from `GET /api/auth/me`.
  * The module is default-on, so `=== false` is the only state that hides the

--- a/src/components/layout/nav-model.ts
+++ b/src/components/layout/nav-model.ts
@@ -194,7 +194,7 @@ export const NAV_DESTINATIONS: ReadonlyArray<NavDestination> = [
     tourId: "nav-illness",
     requiresModule: "illness",
   },
-  // v1.38.0 — the immunization log sits in the clinical spine beside Illness.
+  // v1.37.3: the immunization log sits in the clinical spine beside Illness.
   // Born-gated: `requiresModule: "vaccinations"` reads the resolved module map,
   // so the entry is absent until the account keeps the module on (default-on —
   // it drops only when a user turns it off). SURFACE-gated: the `/api/vaccinations*`


### PR DESCRIPTION
The immunization record (Vaccinations module), plus the settings, mood and sharing polish queued behind it, and two fixes that came out of building the boosters: a maximum-interval preventive-care reminder that lost its next date on satisfy, and two picker controls without a screen-reader name.

Full detail in the CHANGELOG.