### PR TITLE
v1.37.12 — the public privacy policy matches the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.37.12] — 2026-08-11
+
+### Changed
+
+- The public privacy policy now matches the current app and server data flow in German and English. It explains the in-app account-deletion route and MFA handoff, optional server-managed and bring-your-own assistant providers, on-device processing, document and OCR use, consent revocation, Apple Health sync versus HealthLog storage, retention rules, heart-rate representation, the full App Store data categories, and that HealthLog does not track you.
+
 ## [1.37.11] — 2026-08-10
 
 ### Changed

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.37.11
+  version: 1.37.12
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.37.11",
+  "version": "1.37.12",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/src/app/privacy/__tests__/page.test.tsx
+++ b/src/app/privacy/__tests__/page.test.tsx
@@ -31,7 +31,7 @@ function render() {
   return renderToStaticMarkup(<PrivacyPage />);
 }
 
-const POLICY_VERSION = "1.37.11";
+const POLICY_VERSION = "1.37.12";
 const LAST_UPDATED = "2026-08-11";
 
 describe("<PrivacyPage>", () => {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -36,7 +36,7 @@ import Link from "next/link";
 
 export const dynamic = "force-dynamic";
 
-const POLICY_VERSION = "1.37.11";
+const POLICY_VERSION = "1.37.12";
 const LAST_UPDATED = "2026-08-11";
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## What changed

- bumps the server and generated OpenAPI contract to 1.37.12
- records the public privacy disclosure update in the changelog
- synchronizes the rendered privacy-policy version and its regression test

## Why

The updated bilingual privacy policy is now on `main` and needs a distinct release image so the deployed public page can be traced to the exact source revision.

## Impact

The release publishes the corrected public disclosure. It does not include a database migration or change API behavior.

## Validation

- all required check-runs passed on the exact pre-release main SHA `40e2c71f42aa0e7dee2e9669c9d0324053a19471`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `TZ=UTC pnpm test`
- `pnpm build`
- generated OpenAPI contract is in sync
