### PR TITLE
Bump every codeql-action reference together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       # minutes and can produce nothing actionable, because nobody edits
       # it and the fix for anything found there is `pnpm prisma generate`.
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           build-mode: none
@@ -68,6 +68,6 @@ jobs:
               - public
 
       - name: Analyse
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -54,7 +54,7 @@ jobs:
           publish_results: true
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: scorecard-results.sarif
           category: scorecard

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -88,7 +88,7 @@ jobs:
           skip-dirs: src/generated
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-filesystem.sarif
           category: trivy-filesystem
@@ -145,7 +145,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: trivy-published-image.sarif
           category: trivy-published-image


### PR DESCRIPTION
Dependabot opened #802 (`init`) and #803 (`upload-sarif`) separately, because it tracks each action path as its own dependency. That splits a version pair that cannot be split: `codeql.yml` runs `init` and `analyze` in the same job, and raising only `init` makes the action refuse to run.

> Loaded a configuration file for version '4.37.7', but running version '4.37.6'

The CodeQL job failed on #802 for exactly that reason, so the bump could not have merged on its own.

This moves all five pinned references at once: `init` and `analyze` in `codeql.yml`, plus the three `upload-sarif` steps in `scorecard.yml` and `trivy.yml`. The commit SHA is what the `v4.37.7` tag dereferences to, and it matches the SHA both Dependabot PRs pin.

Closes #802
Closes #803