### PR TITLE
Force the patched deepmerge-ts through Prisma's config loader

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   ip-address@<10.3.1: ^10.3.1
   sharp@<0.35.0: ^0.35.3
   pdfjs-dist@>=5.6.83 <6.2.108: 6.2.108
+  deepmerge-ts@<8.0.0: ^8.0.0
 
 importers:
 
@@ -4079,8 +4080,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -8869,7 +8870,7 @@ snapshots:
   '@prisma/config@7.8.0(magicast@0.5.2)':
     dependencies:
       c12: 3.3.4(magicast@0.5.2)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       effect: 3.20.0
       empathic: 2.0.0
     transitivePeerDependencies:
@@ -11010,7 +11011,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,12 @@ overrides:
   # `pdf-parse` resolves 5.4.296, which predates the flaw and drives the local
   # text-extraction path, so it must not be dragged onto a new major.
   "pdfjs-dist@>=5.6.83 <6.2.108": "6.2.108"
+  # Deeply nested input drives DeepmergeTS into unbounded recursion until the
+  # stack gives out. The copy here is Prisma's: `@prisma/config` still asks for
+  # 7.1.5 even on the current 7.9.1, so no Prisma bump reaches it and the
+  # override is the only way through. It runs on the config-loading and CLI
+  # path, not under a request, but a red audit blocks the whole release train.
+  "deepmerge-ts@<8.0.0": "^8.0.0"
 
 allowBuilds:
   "@prisma/engines": true


### PR DESCRIPTION
The dependency audit went red on the trunk without a line of our code changing.
DeepmergeTS recurses without bound on deeply nested input until the stack gives
out (GHSA-ggr8-5vv4-36mx, fixed in 8.0.0), and the advisory landed after the
last green run.

Confirmed it is drift rather than a branch: re-running the same job against the
same `main` commit that passed on 16 August fails today.

## Why an override

Waiting for Prisma does not help. `@prisma/config` still asks for 7.1.5 on the
current 7.9.1, so the copy never updates on its own. The workflow reserves
`auditConfig.ignoreCves` for advisories with no upstream fix; this one has a
fix, so suppressing it would be the wrong tool. The override follows the shape
the other nine in `pnpm-workspace.yaml` already use.

The reach is Prisma's config-loading and CLI path rather than anything under a
request, so practical exposure was small. The blocked release train was not.

## Proof

`pnpm audit --prod --audit-level=high`, the exact command CI runs, goes from
twelve findings with one high to eleven with none, exit clean. The eleven that
remain are the low and moderate set the gate already tolerates.

This is a major bump sitting under Prisma's own config loader, so it was not
enough to watch the audit turn green:

- `prisma generate` passes
- `prisma validate` passes
- typecheck, lint, format:check pass
- 21446 unit tests across 1885 files pass
- the production build passes

Found while checking why the dependency audit was red on PR #806.
