### PR TITLE
Point the doctor-report references at the route that exists

### DIFF
--- a/CONTRIBUTING-AI.md
+++ b/CONTRIBUTING-AI.md
@@ -108,7 +108,7 @@ docker compose logs -f app    # Tail app logs
 - **ESLint**: Strict `react-hooks/set-state-in-effect` rule — avoid `setState` inside `useEffect`. Use lazy `useState()` initializer for localStorage reads
 - **Proxy route protection**: `src/proxy.ts` checks `healthlog_session` cookie; PUBLIC_PATHS array bypasses auth. Security headers (CSP, HSTS, X-Frame-Options) applied to all responses
 - **PWA safe area**: Root layout has `viewportFit: "cover"`. Bottom-nav uses `pb-[env(safe-area-inset-bottom)]` for iOS safe area
-- **Doctor report PDF**: Client-side via `src/lib/doctor-report-pdf.ts` (jsPDF). Data from `POST /api/doctor-report`. European medical format, German terminology
+- **Doctor report PDF**: rendered from `src/lib/doctor-report-pdf-core.ts` (jsPDF), the same module in the browser and on the server; the server side is the clinician share link's `/c/[token]/report.pdf`. European medical format, German terminology
 - **Achievements**: Persistent in `UserAchievement` table. Computed on API call, new unlocks written to DB with stable `unlockedAt` timestamps
 - **Data backup**: pg-boss `data-backup` queue runs weekly (Sundays 03:00), stores JSON in `DataBackup` model
 - **Wide Events / Structured Logging**: `apiHandler()` wraps all API routes. Use `annotate()` from `@/lib/logging/context` for business-action annotations. Use `requireAuth()` / `requireAdmin()` from `@/lib/api-handler` (auto-annotates auth). Background jobs use `withBackgroundEvent()`. External calls tracked via `getEvent()?.addExternalCall()`. No `console.log` in production code — use event annotations instead. Env vars: `LOG_LEVEL`, `LOG_SAMPLE_RATE`, `LOG_SLOW_THRESHOLD_MS`, `LOG_INCLUDE_STACK`, `LOKI_ENDPOINT`, `LOKI_USERNAME`, `LOKI_PASSWORD`

--- a/src/lib/doctor-report-pdf-core.ts
+++ b/src/lib/doctor-report-pdf-core.ts
@@ -2,7 +2,10 @@
  * Isomorphic PDF renderer for the doctor report.
  *
  * Runs identically in the browser (settings page download) and in Node
- * (server-rendered `/api/doctor-report/pdf` endpoint). All locale-sensitive
+ * (the clinician share link's `/c/[token]/report.pdf` route). The comment here
+ * named `/api/doctor-report/pdf` until 2026-08-23; that route was removed and
+ * the sweep behind the retired-route registry found the reference still
+ * standing. All locale-sensitive
  * strings and number/date formatting are driven by the injected
  * `{ t, locale }` so DE and EN output match the user's UI language.
  *


### PR DESCRIPTION
Two references to `/api/doctor-report`, a route family removed some releases ago and now registered as retired.

`CONTRIBUTING-AI.md` sent a reader to a POST endpoint that answers nothing, and the renderer's own file header described itself as serving an endpoint that is gone. Both now point at `/c/[token]/report.pdf`, which is what actually builds the report.

Found by sweeping the repository against the retired-route registry, which asks a different question than "does a client still call this": it asks what this repository still tells a reader. Two hits, both prose, neither a call.
