### PR TITLE
Patch OS packages in the runtime image at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,13 @@ FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb
 # `tzdata` is required so Europe/Berlin schedules (pg-boss cron, locale-aware
 # timestamp formatting) resolve to the actual offset instead of silently
 # falling back to UTC on Alpine images that ship without it.
-RUN apk add --no-cache tzdata
+#
+# `apk upgrade` pulls in OS-package security fixes the pinned base digest
+# has not absorbed yet (the digest pin stays for build reproducibility;
+# security patches from the Alpine repo override it deliberately —
+# CVE-2026-14456 in openssl was the first instance the container scan
+# caught between base-image rebuilds).
+RUN apk add --no-cache tzdata && apk upgrade --no-cache
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
The Container Security scan on main flags CVE-2026-14456 (openssl, HIGH, DoS via unbounded memory growth in the QUIC server): the pinned node:22-alpine digest carries libssl3/libcrypto3 3.5.7-r0, and Alpine has published the fix as 3.5.8-r0. The runner stage now runs apk upgrade after apk add, so published OS security fixes reach the image without giving up the digest pin. Verified against the pinned base image that 3.5.8-r0 is available from the Alpine v3.24 repo.