### PR TITLE
release: v1.37.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.37.30] — 2026-08-27
+
+An operator pointing the global AI provider at a private OpenAI-compatible proxy got a network refusal on every call, and nothing said why.
+
+### Fixed
+
+- The operator's global AI provider can now reach a private host, provided that host is named in ALLOW_LOCAL_AI_PRIVATE_HOSTS. Its base URL is typed by the operator in the admin settings, so it now consults the same allowlist as the user-configured gateway instead of being pinned to public hosts. A private host that is not allowlisted is refused exactly as before, personal API keys keep the pinned public posture, and the ChatGPT sign-in path stays fully pinned.
+
 ## [1.37.29] — 2026-08-26
 
 The chart range selector said points and meant days. Someone who weighs in twice a week picked "7 pts", saw two, and reasonably concluded the chart was broken.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.37.29
+  version: 1.37.30
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.37.29",
+  "version": "1.37.30",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.37.29";
+  /* @sw-version-fallback */ "v1.37.30";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`

--- a/src/lib/__tests__/ssrf-pin-inventory.test.ts
+++ b/src/lib/__tests__/ssrf-pin-inventory.test.ts
@@ -8,7 +8,8 @@
  * A future edit that drops the pin (re-opening the SSRF surface) fails here
  * instead of shipping silently.
  *
- * The LOCAL AI client is the deliberate exception: it stays CONDITIONAL
+ * The LOCAL AI client and (since v1.37.30) the openai-client's gateway and
+ * admin-key tags are the deliberate exceptions: they stay CONDITIONAL
  * (`requirePublicHost: !allowPrivate`) so an operator can opt into LAN hosts
  * via `ALLOW_LOCAL_AI_PRIVATE_HOSTS`. v1.18.7 (SECURITY LOW) — that flag is
  * now a host ALLOWLIST (`true` = any private host; a comma-separated list =
@@ -26,8 +27,16 @@ const SRC = join(__dirname, "..");
 const read = (rel: string) => readFileSync(join(SRC, rel), "utf8");
 
 describe("SSRF requirePublicHost pin inventory", () => {
-  it("openai-client pins the BYO base-URL outbound unconditionally", () => {
-    expect(read("ai/openai-client.ts")).toMatch(/requirePublicHost:\s*true/);
+  // v1.37.30 — openai-client is no longer a blanket pin: the gateway and
+  // admin-key tags carry a person-typed base URL and route through the
+  // operator allowlist helper, with `true` as the ternary floor for every
+  // other tag (codex). We assert the exact conditional shape so a future
+  // edit can neither drop the floor nor widen the condition silently.
+  it("openai-client routes person-typed base URLs through the allowlist with a pinned floor", () => {
+    const src = read("ai/openai-client.ts");
+    expect(src).toMatch(
+      /requirePublicHost:\s*this\.isGateway \|\| this\.type === "admin-key"\s*\? requirePublicHostFor\(this\.config\.baseUrl\)\s*:\s*true/,
+    );
   });
 
   it("anthropic-client pins the BYO base-URL outbound unconditionally", () => {

--- a/src/lib/ai/__tests__/openai-compatible-client.test.ts
+++ b/src/lib/ai/__tests__/openai-compatible-client.test.ts
@@ -9,9 +9,11 @@ import { singleUserTurn } from "../types";
  * Two properties carry the security weight of this provider and are pinned
  * here rather than left to review:
  *
- *   1. The pinned `admin-key` / `codex` tags keep `requirePublicHost: true`
- *      no matter what the operator allowlisted. Only the gateway tag — whose
- *      base URL a person typed — consults the allowlist.
+ *   1. The `codex` tag keeps `requirePublicHost: true` no matter what the
+ *      operator allowlisted — its base URL is a repository constant. The
+ *      gateway and `admin-key` tags — the two whose base URL a person can
+ *      type — consult the allowlist, and without an allowlist entry a
+ *      private host is refused exactly as before (v1.37.30).
  *   2. The SSRF floor under the gateway is `isPublicUrl`, which is the same
  *      floor the Local provider sits on, including every IPv4 / IPv6
  *      alt-notation class.
@@ -168,18 +170,52 @@ describe("OpenAI-compatible gateway — host policy", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the pinned tags on requirePublicHost even when the operator allowlisted the host", async () => {
+  // v1.37.30 — the admin-key tag joined the allowlist policy: its base URL
+  // is operator-typed in exactly one place (the global provider in the admin
+  // settings, e.g. pointed at a private OpenAI-compatible OAuth proxy), and
+  // the allowlist is the operator's own grant. The floor is unchanged: a
+  // private host WITHOUT an allowlist entry is refused, and the codex tag
+  // stays hard-pinned because its base URL is a repository constant. Note
+  // that every non-operator admin-key construction in the app pins the
+  // public `api.openai.com` constant, so the personal-key posture cannot
+  // reach this branch.
+  it("admin-key consults the allowlist for an operator-typed private host", async () => {
+    const fetchMock = okReply();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("ALLOW_LOCAL_AI_PRIVATE_HOSTS", "openai-oauth-proxy");
+
+    await new OpenAIClient({
+      apiKey: "unused-behind-proxy",
+      model: "gpt-4o",
+      baseUrl: "http://openai-oauth-proxy:10531/v1",
+    }).generateCompletion(jsonTurn());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("admin-key still refuses a private host the operator did not allowlist", async () => {
     vi.stubGlobal("fetch", okReply());
-    // The operator opened every private host for their local AI endpoint.
-    // That opt-in belongs to the gateway/local surface; a client carrying an
-    // OpenAI-issued key must not inherit it.
-    vi.stubEnv("ALLOW_LOCAL_AI_PRIVATE_HOSTS", "true");
+    vi.stubEnv("ALLOW_LOCAL_AI_PRIVATE_HOSTS", "");
 
     await expect(
       new OpenAIClient({
         apiKey: "sk-user-openai-key",
         model: "gpt-4o",
         baseUrl: "http://192.168.1.5:4000/v1",
+      }).generateCompletion(jsonTurn()),
+    ).rejects.toMatchObject({ kind: "private_host" });
+  });
+
+  it("codex stays pinned to public hosts even under a blanket allowlist", async () => {
+    vi.stubGlobal("fetch", okReply());
+    vi.stubEnv("ALLOW_LOCAL_AI_PRIVATE_HOSTS", "true");
+
+    await expect(
+      new OpenAIClient({
+        apiKey: "codex-access-token",
+        model: "gpt-5.4",
+        baseUrl: "http://192.168.1.5:4000/v1",
+        providerType: "codex",
       }).generateCompletion(jsonTurn()),
     ).rejects.toMatchObject({ kind: "private_host" });
   });

--- a/src/lib/ai/openai-client.ts
+++ b/src/lib/ai/openai-client.ts
@@ -35,11 +35,13 @@ interface OpenAIClientConfig {
    * to log as "codex" instead.
    *
    * v1.33.1 (#470) — `openai-compatible` is the user-configured gateway
-   * (LiteLLM / OpenRouter / vLLM). It is the ONLY tag whose `baseUrl` is not
-   * a HealthLog-pinned constant, and the two behaviours below hang off it:
-   * the operator's private-host allowlist may apply, and the JSON-mode
-   * dialect is learned per endpoint instead of assumed. Every other tag
-   * keeps the pinned `api.openai.com` posture unchanged.
+   * (LiteLLM / OpenRouter / vLLM). Its `baseUrl` always comes from a person,
+   * and two behaviours hang off that: the operator's private-host allowlist
+   * may apply, and the JSON-mode dialect is learned per endpoint instead of
+   * assumed. `admin-key` carries a person-typed base URL in exactly one
+   * place (the operator's global provider in the admin settings) and shares
+   * the allowlist policy for it since v1.37.30; the dialect stays assumed.
+   * `codex` keeps the fully pinned posture.
    */
   providerType?: OpenAIProviderType;
 }
@@ -148,14 +150,25 @@ export class OpenAIClient implements AIProvider {
       // v1.21.5 — honour the caller's per-request timeout override; default 60 s.
       // v1.33.1 (#470) — the gateway tag reuses the Local provider's host
       // policy verbatim: public hosts always; a private host only when the
-      // operator allowlisted it via ALLOW_LOCAL_AI_PRIVATE_HOSTS. Every other
-      // tag stays pinned to `requirePublicHost: true` — `api.openai.com` is
-      // public and there is nothing to opt into.
+      // operator allowlisted it via ALLOW_LOCAL_AI_PRIVATE_HOSTS.
+      //
+      // v1.37.30 — the `admin-key` tag consults the same policy. Its base URL
+      // is the one other operator-typed URL in this client (an operator can
+      // point the global provider at a private OpenAI-compatible proxy, e.g.
+      // an OAuth sidecar), and both ends of the grant are the operator's own:
+      // the URL comes from the admin settings, the allowlist from the
+      // operator's environment. Every non-operator construction of this tag
+      // pins the public `api.openai.com` constant, for which the policy
+      // resolves to `true` without ever consulting the allowlist — so the
+      // personal-key posture is unchanged. The `codex` tag keeps the hard
+      // pin: its base URL is a repository constant, there is nothing an
+      // operator legitimately redirects.
       {
         timeoutMs: params.timeoutMs ?? 60_000,
-        requirePublicHost: this.isGateway
-          ? requirePublicHostFor(this.config.baseUrl)
-          : true,
+        requirePublicHost:
+          this.isGateway || this.type === "admin-key"
+            ? requirePublicHostFor(this.config.baseUrl)
+            : true,
         signal: params.signal,
       },
     );


### PR DESCRIPTION
An operator pointing the global AI provider at a private OpenAI-compatible proxy got a safeFetch refusal on every call, indistinguishable from an outage.

- The admin provider's base URL is operator-typed, so its tag now consults the same ALLOW_LOCAL_AI_PRIVATE_HOSTS policy as the user-configured gateway. A public URL never consults the allowlist, an unlisted private host is refused exactly as before, personal keys keep the pinned public posture, and the codex tag stays hard-pinned to its repository-constant base URL.
- The test that asserted the old blanket pin is split into the three cases that actually differ: allowlisted private host passes, unlisted private host refuses, codex refuses even a blanket allowlist.

No API surface change; the OpenAPI regen carries only the version bump.