### PR TITLE
fix: show short password labels as invalid

### DIFF
--- a/src/components/ui/password-strength.tsx
+++ b/src/components/ui/password-strength.tsx
@@ -69,11 +69,12 @@ export function PasswordStrength({
     t("passwordStrength.strong"),
     t("passwordStrength.veryStrong"),
   ];
-  const tooShort = password.length < minLength;
+  const isTooShort = password.length < minLength;
+  const labelColor = isTooShort ? "text-destructive" : colors.textColor;
 
   // Collect feedback
   const feedback: string[] = [];
-  if (tooShort) {
+  if (isTooShort) {
     feedback.push(t("passwordStrength.minLength", { count: minLength }));
   }
   if (result?.feedback?.warning) {
@@ -92,7 +93,7 @@ export function PasswordStrength({
             key={i}
             className={cn(
               "h-1.5 flex-1 rounded-full transition-colors",
-              i <= score && !tooShort ? colors.color : "bg-muted",
+              i <= score && !isTooShort ? colors.color : "bg-muted",
             )}
           />
         ))}
@@ -100,8 +101,8 @@ export function PasswordStrength({
 
       {/* Label */}
       <div className="flex items-center justify-between">
-        <span className={cn("text-xs font-medium", colors.textColor)}>
-          {tooShort ? t("passwordStrength.tooShort") : scoreLabels[score]}
+        <span className={cn("text-xs font-medium", labelColor)}>
+          {isTooShort ? t("passwordStrength.tooShort") : scoreLabels[score]}
         </span>
         <span className="text-muted-foreground text-xs">
           {password.length}/{minLength}+ {t("passwordStrength.characters")}


### PR DESCRIPTION
## Summary

Show the “Zu kurz” password-feedback label in the destructive color when the password fails the minimum-length requirement, even if zxcvbn rates its entropy highly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [ ] Test / CI / tooling
- [ ] Refactor (no functional change)

## Test plan

- [ ] Enter a password shorter than 12 characters that otherwise scores strong; confirm “Zu kurz” is destructive/red.
- [ ] Enter a 12+ character password; confirm its label retains score-based coloring.

## Screenshots (UI changes only)

Not included.

## Checklist

- [x] Targets the `main` branch
- [x] `pnpm typecheck` passes locally
- [x] `pnpm lint` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm format:check` passes locally
- [ ] `pnpm build` passes locally
- [x] No user-facing strings were added or changed
- [x] No secrets, personal data, or maintainer-name references in committed files
- [ ] Updated `CHANGELOG.md` if user-visible
- [ ] Updated `docs/audit/` or `docs.healthlog.dev` if behavior or self-hosting docs change

## Linked issues

None.