### PR TITLE
Shows warning for misconfigured callback urls

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "Noch {count} Messungen bis zum Trend."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: Die Callback-Adresse {configuredOrigin} unterscheidet sich von der App-Adresse {currentOrigin}.",
     "shell": {
       "sectionsNav": "Einstellungs-Bereiche",
       "groups": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "{count} more readings to go."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "Settings sections",
       "groups": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "Faltan {count} mediciones para la tendencia."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "Secciones de ajustes",
       "groups": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -4636,7 +4636,7 @@
     "remainingMany": "Faltan {count} mediciones para la tendencia."
   },
   "settings": {
-    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
+    "oauthCallbackPreflightItem": "{provider}: la dirección de retorno {configuredOrigin} no coincide con la dirección de esta aplicación {currentOrigin}.",
     "shell": {
       "sectionsNav": "Secciones de ajustes",
       "groups": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "Encore {count} mesures avant la tendance."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sections des réglages",
       "groups": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4636,7 +4636,7 @@
     "remainingMany": "Encore {count} mesures avant la tendance."
   },
   "settings": {
-    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
+    "oauthCallbackPreflightItem": "{provider} : l'adresse de rappel {configuredOrigin} diffère de l'adresse de cette application {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sections des réglages",
       "groups": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4636,7 +4636,7 @@
     "remainingMany": "Mancano {count} misurazioni al trend."
   },
   "settings": {
-    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
+    "oauthCallbackPreflightItem": "{provider}: l'indirizzo di callback {configuredOrigin} non corrisponde all'indirizzo di questa applicazione {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sezioni delle impostazioni",
       "groups": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "Mancano {count} misurazioni al trend."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sezioni delle impostazioni",
       "groups": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "{count}개만 더 기록하면 돼요."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "설정 섹션",
       "groups": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -4636,7 +4636,7 @@
     "remainingMany": "{count}개만 더 기록하면 돼요."
   },
   "settings": {
-    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
+    "oauthCallbackPreflightItem": "{provider}: 콜백 주소 {configuredOrigin}이(가) 이 앱 주소 {currentOrigin}과(와) 다릅니다.",
     "shell": {
       "sectionsNav": "설정 섹션",
       "groups": {

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -4636,6 +4636,7 @@
     "remainingMany": "Jeszcze {count} pomiarów do trendu."
   },
   "settings": {
+    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sekcje ustawień",
       "groups": {

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -4636,7 +4636,7 @@
     "remainingMany": "Jeszcze {count} pomiarów do trendu."
   },
   "settings": {
-    "oauthCallbackPreflightItem": "{provider}: callback address {configuredOrigin} differs from this app address {currentOrigin}.",
+    "oauthCallbackPreflightItem": "{provider}: adres zwrotny {configuredOrigin} różni się od adresu tej aplikacji {currentOrigin}.",
     "shell": {
       "sectionsNav": "Sekcje ustawień",
       "groups": {

--- a/src/components/settings/integrations/fitbit-card.tsx
+++ b/src/components/settings/integrations/fitbit-card.tsx
@@ -65,8 +65,10 @@ import {
   type SyncOutcomeState,
 } from "./sync-outcome";
 import {
+  CallbackMismatchNotice,
   IntegrationCardDescription,
   IntegrationRedirectGuide,
+  integrationCallbackUrl,
 } from "./setup-guide-link";
 
 export function FitbitCard({
@@ -521,6 +523,10 @@ export function FitbitCard({
           </p>
         )}
       </div>
+      <CallbackMismatchNotice
+        provider={t("settings.fitbit")}
+        callbackUrl={integrationCallbackUrl("fitbit")}
+      />
     </SettingsCard>
   );
 }

--- a/src/components/settings/integrations/google-health-card.tsx
+++ b/src/components/settings/integrations/google-health-card.tsx
@@ -80,7 +80,11 @@ import {
   type SyncOutcomeResource,
   type SyncOutcomeState,
 } from "./sync-outcome";
-import { IntegrationCardDescription } from "./setup-guide-link";
+import {
+  CallbackMismatchNotice,
+  IntegrationCardDescription,
+  integrationCallbackUrl,
+} from "./setup-guide-link";
 
 export function GoogleHealthCard({
   viewModel,
@@ -758,6 +762,10 @@ export function GoogleHealthCard({
           </p>
         )}
       </div>
+      <CallbackMismatchNotice
+        provider={t("settings.googleHealth")}
+        callbackUrl={integrationCallbackUrl("google-health")}
+      />
     </SettingsCard>
   );
 }

--- a/src/components/settings/integrations/oauth-provider-card.tsx
+++ b/src/components/settings/integrations/oauth-provider-card.tsx
@@ -65,9 +65,11 @@ import {
   pillStateForVerdict,
 } from "./shared";
 import {
+  CallbackMismatchNotice,
   IntegrationCardDescription,
   IntegrationRedirectGuide,
   type IntegrationDocsProvider,
+  integrationCallbackUrl,
 } from "./setup-guide-link";
 
 export interface OAuthProviderStatus {
@@ -522,6 +524,10 @@ export function OAuthProviderCard({
           </p>
         )}
       </div>
+      <CallbackMismatchNotice
+        provider={t(i18nPrefix)}
+        callbackUrl={integrationCallbackUrl(provider)}
+      />
     </SettingsCard>
   );
 }

--- a/src/components/settings/integrations/setup-guide-link.tsx
+++ b/src/components/settings/integrations/setup-guide-link.tsx
@@ -11,6 +11,7 @@
  * destination now so a user who is mid-setup always knows where to go.
  */
 
+import { useSyncExternalStore } from "react";
 import { ExternalLink } from "lucide-react";
 
 import { useTranslations } from "@/lib/i18n/context";
@@ -49,6 +50,44 @@ export function integrationCallbackUrl(
 ): string {
   const base = process.env.NEXT_PUBLIC_APP_URL ?? "";
   return `${base}/api/${provider}/callback`;
+}
+
+/** Shows a compact warning when the callback origin differs from the app. */
+export function CallbackMismatchNotice({
+  provider,
+  callbackUrl,
+}: {
+  provider: string;
+  callbackUrl: string;
+}) {
+  // Get the current origin of the app
+  const { t } = useTranslations();
+  const currentOrigin = useSyncExternalStore(
+    () => () => {},
+    () => window.location.origin,
+    () => null,
+  );
+  // Get the origin of the callback URL
+  const callbackOrigin = (() => {
+    try {
+      return new URL(callbackUrl).origin;
+    } catch {
+      return null;
+    }
+  })();
+  if (!currentOrigin || !callbackOrigin || callbackOrigin === currentOrigin) {
+    return null;
+  }
+  // If the callback origin differs from the app, show a warning
+  return (
+    <span className="text-warning border-warning/30 bg-warning/5 block rounded-md border px-2 py-1 text-xs">
+      {t("settings.oauthCallbackPreflightItem", {
+        provider,
+        configuredOrigin: callbackOrigin,
+        currentOrigin,
+      })}
+    </span>
+  );
 }
 
 /**

--- a/src/components/settings/integrations/whoop-card.tsx
+++ b/src/components/settings/integrations/whoop-card.tsx
@@ -56,8 +56,10 @@ import {
   type SyncOutcomeState,
 } from "./sync-outcome";
 import {
+  CallbackMismatchNotice,
   IntegrationCardDescription,
   IntegrationRedirectGuide,
+  integrationCallbackUrl,
 } from "./setup-guide-link";
 
 export function WhoopCard({
@@ -503,6 +505,10 @@ export function WhoopCard({
           </p>
         )}
       </div>
+      <CallbackMismatchNotice
+        provider={t("settings.whoop")}
+        callbackUrl={integrationCallbackUrl("whoop")}
+      />
     </SettingsCard>
   );
 }

--- a/src/components/settings/integrations/withings-card.tsx
+++ b/src/components/settings/integrations/withings-card.tsx
@@ -55,8 +55,10 @@ import {
   type SyncOutcomeState,
 } from "./sync-outcome";
 import {
+  CallbackMismatchNotice,
   IntegrationCardDescription,
   IntegrationRedirectGuide,
+  integrationCallbackUrl,
 } from "./setup-guide-link";
 
 export function WithingsCard({
@@ -552,6 +554,10 @@ export function WithingsCard({
           </p>
         )}
       </div>
+      <CallbackMismatchNotice
+        provider={t("settings.withings")}
+        callbackUrl={integrationCallbackUrl("withings")}
+      />
     </SettingsCard>
   );
 }


### PR DESCRIPTION
## Summary

Adds a compact OAuth callback warning to each integration card when the configured callback address differs from the current app address.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only
- [ ] Test / CI / tooling
- [ ] Refactor (no functional change)

## Test plan

- [x] Focused tests pass: 53 tests
- [x] Direct TypeScript check passes with an 8 GB heap
- [ ] Full test suite passes: 73 existing failures remain

## Screenshots (UI changes only)

<img width="501" height="214" alt="image" src="https://github.com/user-attachments/assets/898913cb-d6d4-4953-a973-dc473ad66641" />

## Checklist

- [x] Targets the `main` branch (trunk-based — see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] `pnpm typecheck` passes locally
- [x] `pnpm lint` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm format:check` passes locally
- [ ] `pnpm build` passes locally
- [x] User-facing strings go through `t("key")` with locale catalogs updated
- [x] No secrets, personal data, or maintainer-name references in committed files
- [ ] Updated `CHANGELOG.md` if user-visible
- [ ] Updated `docs/audit/` or `docs.healthlog.dev` if behavior or self-hosting docs change