### PR TITLE
fix: the geometry guard has never measured in CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,6 +28,26 @@ jobs:
 
       - run: pnpm db:generate
 
+      # The hero-geometry check in the unit suite renders the real panel in a
+      # real browser and measures the boxes. Without a browser here it caught
+      # its own launch failure and passed anyway, so from its first day until
+      # v1.38 it measured nothing on any run of this job. The browser is part
+      # of the gate now; the test refuses to skip when CI is set.
+      #
+      # Headless shell only: `chromium.launch()` resolves to
+      # chromium_headless_shell, which is what the failing runs named, and the
+      # full headed build is several times the download for nothing this job
+      # uses. The e2e job keeps `--with-deps chromium` — it drives a real app.
+      - name: Cache Playwright headless shell
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-shell-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-shell-${{ runner.os }}-
+
+      - run: pnpm exec playwright install --only-shell chromium
+
       # Blocking since v1.15.20 — the settings-split refactor that kept
       # this warn-only is long done and the tree lints clean.
       - name: ESLint

--- a/src/components/insights/__tests__/health-score-card-geometry.test.tsx
+++ b/src/components/insights/__tests__/health-score-card-geometry.test.tsx
@@ -32,11 +32,14 @@ import { HeroStrip } from "../hero-strip";
  * that printed them and are reported as such, never baked into a comment as
  * if they were a property of the design.
  *
- * It needs a Chromium build. `pnpm test` on a machine that has one (any
- * machine that has run `pnpm e2e`) measures for real; a machine without one
- * skips loudly rather than passing quietly. The unit CI job installs no
- * browsers, so treat this as a check for the person editing the panel and for
- * the release audit, not as the gate.
+ * It needs a Chromium build, and under CI it IS the gate: the quality job
+ * installs the headless shell before the unit suite, and a launch failure
+ * there fails this suite instead of skipping it. That is the whole point —
+ * until v1.38 the job installed no browsers, every run caught the launch
+ * error and passed, and the check had never measured anything in CI. On a
+ * developer machine without a browser it still skips, loudly, so that
+ * `pnpm test` stays usable; run `pnpm exec playwright install --only-shell
+ * chromium` once to measure for real.
  */
 
 vi.mock("@/hooks/use-auth", () => ({
@@ -219,9 +222,20 @@ beforeAll(async () => {
     const { chromium } = await import("@playwright/test");
     browser = await chromium.launch();
   } catch (error) {
-    skipReason = `no Chromium build available (${String(error).slice(0, 120)})`;
-    // Loud on purpose: a geometry check that quietly skips is the same thing
-    // as no geometry check, and this repo has shipped that before.
+    const reason = `no Chromium build available (${String(error).slice(0, 200)})`;
+    // In CI the browser is installed by the quality job, so a launch failure
+    // is the job being wrong, not the machine being bare. Throwing from the
+    // hook fails every test in this suite: a geometry check that quietly
+    // skips is the same thing as no geometry check, and this repo shipped
+    // exactly that for months because the skip only ever reached a console
+    // line nobody reads.
+    if (process.env.CI) {
+      throw new Error(
+        `[hero geometry] ${reason}. This check is the gate in CI and it has no browser to measure with. ` +
+          `Restore the "pnpm exec playwright install --only-shell chromium" step in the quality job of .github/workflows/security.yml.`,
+      );
+    }
+    skipReason = reason;
     console.warn(`[hero geometry] SKIPPED — ${skipReason}`);
     return;
   }
@@ -252,8 +266,8 @@ const PANEL = '[data-slot="health-score-card"]';
 const RESERVE = '[data-slot="health-score-card-skeleton"]';
 
 describe("hero band geometry", () => {
-  it("holds a reserve that sits inside the range the real report produces", async () => {
-    if (skipReason) return expect(skipReason).toBeTruthy();
+  it("holds a reserve that sits inside the range the real report produces", async (ctx) => {
+    if (skipReason) ctx.skip(skipReason);
 
     const heights: Record<string, number> = {};
     const shapes: { key: string; report: HealthScoreReport }[] = [
@@ -337,8 +351,8 @@ describe("hero band geometry", () => {
     ).toBeLessThanOrEqual(heights.rows6);
   }, 60_000);
 
-  it("keeps every row on one line in every locale", async () => {
-    if (skipReason) return expect(skipReason).toBeTruthy();
+  it("keeps every row on one line in every locale", async (ctx) => {
+    if (skipReason) ctx.skip(skipReason);
 
     const widest: Record<string, { label: string; natural: number }> = {};
 
@@ -444,13 +458,14 @@ describe("hero band geometry", () => {
     );
   }, 60_000);
 
-  it.each([
+  it.for([
     { width: VIEWPORT_PX, where: "the md column" },
     { width: 360, where: "a 360px phone, stacked under the greeting" },
   ])(
     "never scrolls sideways in $where",
-    async ({ width }) => {
-      if (skipReason) return expect(skipReason).toBeTruthy();
+    { timeout: 60_000 },
+    async ({ width }, ctx) => {
+      if (skipReason) ctx.skip(skipReason);
 
       const target = page!;
       await target.setViewportSize({ width, height: 1200 });
@@ -524,6 +539,5 @@ describe("hero band geometry", () => {
 
       await target.setViewportSize({ width: VIEWPORT_PX, height: 1200 });
     },
-    60_000,
   );
 });


### PR DESCRIPTION
## What was wrong

`src/components/insights/__tests__/health-score-card-geometry.test.tsx` launches Chromium in `beforeAll`, catches a launch failure into a `skipReason`, and every case then returns early with a trivially true assertion. The quality job in `.github/workflows/security.yml` installs no browsers — only the e2e job does. So the check passed on every CI run without measuring a single box.

From run 33312946672 ("Security & Quality" → "Lint, Typecheck & Test" → "Unit tests", main, 2026-08-30):

```
[hero geometry] SKIPPED — no Chromium build available (Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1234/ch)
```

The file's own header warned about this trap — "a geometry check that quietly skips is the same thing as no geometry check, and this repo has shipped that before" — and then stated that the unit job installs no browsers, so treat this as a check for the person editing the panel rather than the gate. That sentence has been rewritten; it is the gate now.

## What changed

**The job gets a browser.** `.github/workflows/security.yml`, `quality` job: a `pnpm exec playwright install --only-shell chromium` step before the ESLint/typecheck/test block, with an `actions/cache` step for `~/.cache/ms-playwright` keyed on the lockfile hash. Headless shell only — `chromium.launch()` resolves to `chromium_headless_shell`, which is the exact path the failing runs named, so the full headed build would be a bigger download for something this job never drives. The e2e job keeps `--with-deps chromium` unchanged. Cache prefix is `playwright-shell-` so the two jobs do not overwrite each other's cache content.

**The check refuses to be optional.** With `CI` set, a launch failure now throws out of `beforeAll` instead of being swallowed, and the message names both the cause and the step to restore. Without `CI` it still skips, so `pnpm test` stays usable on a machine with no browsers — but through the test context (`ctx.skip(reason)`), so the skip and its reason land in the run report instead of a console line nobody reads. The `it.each` block became `it.for` to get that context.

## How it was proven

Guard goes red without a browser under CI:

```
$ CI=1 PLAYWRIGHT_BROWSERS_PATH=<empty dir> pnpm vitest run src/components/insights/__tests__/health-score-card-geometry.test.tsx
 FAIL  src/components/insights/__tests__/health-score-card-geometry.test.tsx
Error: [hero geometry] no Chromium build available (Error: browserType.launch: Executable doesn't exist at <empty dir>/chromium_headless_shell-123). This check is the gate in CI and it has no browser to measure with. Restore the "pnpm exec playwright install --only-shell chromium" step in the quality job of .github/workflows/security.yml.
 Test Files  1 failed (1)
exit 1
```

Same empty browser path without `CI`: exit 0, `Tests 4 skipped (4)`, each skip carrying the reason in the report.

With a real browser it passes and prints real measurements:

```
[hero geometry] column 352px · panel {"rows3":400,"rows4":428,"rows5":456,"rows6":484,"rows3basis":420} · reserve 448px (blocks alone 428px)
[hero geometry] longest label per locale against a 112px column: de "Körperfettverteilung" 147px · en "Blood pressure" 110px · fr "Tension artérielle" 124px · es "Presión arterial" 109px · it "Pressione arteriosa" 139px · pl "Samopoczucie" 107px · ko "마음 건강" 60px
 Tests  4 passed (4)
```

**No panel number was touched.** The measured heights are exactly the ones the reserve was set against: 400 / 428 / 456 / 484 px for three to six rows, 420 px for three rows plus the basis line, 448 px reserve. The assertions remain relational — no range was widened to fit.

And on this branch's own CI run (33315511262, "Lint, Typecheck & Test" green), the same job that used to print SKIPPED now prints measurements:

```
[hero geometry] column 352px · panel {"rows3":400,"rows4":428,"rows5":456,"rows6":484,"rows3basis":420} · reserve 448px (blocks alone 428px)
[hero geometry] longest label per locale against a 112px column: de "Körperfettverteilung" 140px · en "Blood pressure" 108px · …
```

The panel heights the runner reads back are identical to the local ones. The label widths differ by a few px because the fallback typeface differs — which is exactly why the file reports those and asserts only relations.

The headless-shell install cost the job 6 seconds on a cold cache.

## Gate

| Command | Result |
| --- | --- |
| `pnpm typecheck` | pass |
| `pnpm lint` | pass — 0 errors, 3 pre-existing warnings in files this branch does not touch |
| `pnpm format:check` | pass |
| targeted vitest, real browser | pass, 4/4, measurements printed above |
| `pnpm test` | pass — 1919 files, 22342 passed, 12 skipped |
| `pnpm build` | pass |

Integration tests were not run: nothing here touches the score wire or the backup surface.
