### PR TITLE
ci: move every codeql-action pin to v4.37.9 in one commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    groups:
+      # init, analyze and upload-sarif are one release pinned in three places.
+      # Bumped separately, a run mixes two versions and analyze refuses the
+      # config init wrote ("Loaded a configuration file for version 4.37.7, but
+      # running version 4.37.9"), so none of the single-action pull requests can
+      # reach green on its own. They travel together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       # minutes and can produce nothing actionable, because nobody edits
       # it and the fix for anything found there is `pnpm prisma generate`.
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
           build-mode: none
@@ -68,6 +68,6 @@ jobs:
               - public
 
       - name: Analyse
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -54,7 +54,7 @@ jobs:
           publish_results: true
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: scorecard-results.sarif
           category: scorecard

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -88,7 +88,7 @@ jobs:
           skip-dirs: src/generated
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: trivy-filesystem.sarif
           category: trivy-filesystem
@@ -145,7 +145,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: trivy-published-image.sarif
           category: trivy-published-image


### PR DESCRIPTION
Dependabot opened #863, #866 and #870 for `init`, `analyze` and `upload-sarif`. They are the same release pinned in three workflows, so each pull request produced a run that mixed two versions, and `analyze` refused the config that `init` had written:

```
Loaded a configuration file for version '4.37.7', but running version '4.37.9'
```

None of the three could reach green on its own, and code-scanning analysis stayed red while they waited on each other.

This bumps all five references together and groups the action in `dependabot.yml`, so the next release arrives as a single pull request instead of three that block one another.

Supersedes #863, #866 and #870.