### PR TITLE
test(labs): assert the outlier's distance from the edge, not one string

### DIFF
--- a/src/components/targets/__tests__/range-bar.test.tsx
+++ b/src/components/targets/__tests__/range-bar.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { I18nProvider } from "@/lib/i18n/context";
-import { RangeBar } from "../range-bar";
+import { EDGE_PADDING_PERCENT, RangeBar } from "../range-bar";
 
 /**
  * v1.4.25 W3e — `<RangeBar>` was extracted from the inline 790-line
@@ -68,7 +68,18 @@ describe("<RangeBar>", () => {
       tone: "lab",
     });
 
-    expect(html).not.toContain("left: 4%");
+    // Assert the distance, not one unlucky string. `not.toContain("left: 4%")`
+    // passes for a marker at 4.02%, which is the same defect one rounding away.
+    // The marker is the fourth `left:` in the markup — the three before it are
+    // the bar slot and the band edges.
+    const positions = [...html.matchAll(/left:\s*([0-9.]+)%/g)].map((m) =>
+      Number(m[1]),
+    );
+    const marker = positions[3];
+
+    expect(marker).toBeGreaterThan(EDGE_PADDING_PERCENT);
+    // And not flung to the other end by an over-eager expansion.
+    expect(marker).toBeLessThan(100 - EDGE_PADDING_PERCENT);
   });
 
   it("makes the marker focusable with a text alternative for the value + range (2026-07-17 a11y audit M1)", () => {

--- a/src/components/targets/range-bar.tsx
+++ b/src/components/targets/range-bar.tsx
@@ -30,6 +30,14 @@ export interface RangeBarProps {
   maxLabel?: string | null;
 }
 
+/**
+ * How far from either end the value marker is allowed to sit, in percent.
+ *
+ * Module scope rather than the render body so the test can assert against the
+ * same number the component clamps with, instead of a copy that can drift.
+ */
+export const EDGE_PADDING_PERCENT = 4;
+
 export function RangeBar({
   value,
   min,
@@ -83,7 +91,6 @@ export function RangeBar({
   const visualSpan = visualMax - visualMin;
   const clampedValue = Math.max(visualMin, Math.min(visualMax, value));
   const rawPosition = ((clampedValue - visualMin) / visualSpan) * 100;
-  const EDGE_PADDING_PERCENT = 4;
   const position = Math.max(
     EDGE_PADDING_PERCENT,
     Math.min(100 - EDGE_PADDING_PERCENT, rawPosition),


### PR DESCRIPTION
Follow-up to #860. I said in review I would take this on rather than ask @TimonBed for another round, so here it is.

The test that shipped asserts `not.toContain("left: 4%")`. That catches a marker pinned at exactly the clamp and misses one at 4.02%, which is the same defect one rounding away. It now reads the marker position out of the markup and asserts it sits inside the padding at both ends, so an over-eager expansion that flings the value to the far edge fails too.

`EDGE_PADDING_PERCENT` moves to module scope and is exported. The assertion then uses the number the component actually clamps with instead of a literal that can drift apart from it. It was also being reallocated on every render, which is its own small reason to move it.

Verified by mutation rather than by reading: dropping the outlier expansion puts the marker at exactly 4, and the new assertion fails with `expected 4 to be greater than 4`. The old one stayed green through the same mutation.