### PR TITLE
chore(release): v1.38.2 — Anthropic on current models, briefing in your language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.2] — 2026-09-02
+
+Anthropic keys work on current Claude models again, and the daily briefing
+stays in the language you read the app in.
 
 ### Fixed
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.1
+  version: 1.38.2
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.1";
+  /* @sw-version-fallback */ "v1.38.2";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Release v1.38.2: the two fixes merged since v1.38.1, bumped and gated.

- **Anthropic keys work on current Claude models again** (#885): no assistant prefill on JSON calls, replies narrowed to the object body; Claude 5 and Fable count as vision-capable; presets gain Sonnet 5 and Opus 5.
- **The briefing stays in the reader's language** (#886): the cache carries its locale and is never served across languages; job paths resolve a missing account language to the instance default; a structural guard keeps the job tree on the shared resolver. Migration 0335 adds `users.insights_cached_locale`.

Gate on this branch: typecheck, lint (three known warnings), format:check, openapi:check, full unit suite, `pnpm build`. All clean.
