### PR TITLE
chore(release): v1.38.3 — delete from the phone, name every source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.3] — 2026-09-02
+
+An account with two-factor can be deleted from the phone, and every data
+source is called by its name.
 
 ### Fixed
 
+- **An account with two-factor can be deleted from the app.** Deleting
+  the account, and erasing the record while keeping the account, both demand a
+  fresh second-factor proof once a factor is enrolled. That proof lived on the
+  session row, which a native client does not have, so anyone who had turned on
+  TOTP or registered a security key was refused on both endpoints from the app
+  no matter what they sent — the only way through was a browser. The app can
+  now re-prove a factor the same way it already does for second-factor
+  management: mint a single-use elevation at `POST /api/auth/step-up` with a
+  TOTP code, security key, or passkey, and send it back in the `X-Step-Up`
+  header alongside the deletion. The web path is untouched, a token on its own
+  still gets nowhere, a password-proved elevation is refused for erasure just as
+  a password login never satisfied the gate on the web, and the proof is spent
+  only when the erasure is about to run, so a mistyped confirmation does not
+  burn it. One thing to know when erasing the record over a token: API tokens
+  are part of what that request deletes, so the app signs itself out and has to
+  sign in again.
 - Settings, Sources: four of the sources in the priority ladder were listed
   by their internal name. `GOOGLE_HEALTH`, `OURA`, `POLAR` and `STRAVA`
   appeared exactly like that instead of Google Health, Oura, Polar and
@@ -24,22 +43,6 @@ stays in the language you read the app in.
 
 ### Fixed
 
-- **An account with two-factor can be deleted from the app.** Deleting
-  the account, and erasing the record while keeping the account, both demand a
-  fresh second-factor proof once a factor is enrolled. That proof lived on the
-  session row, which a native client does not have, so anyone who had turned on
-  TOTP or registered a security key was refused on both endpoints from the app
-  no matter what they sent — the only way through was a browser. The app can
-  now re-prove a factor the same way it already does for second-factor
-  management: mint a single-use elevation at `POST /api/auth/step-up` with a
-  TOTP code, security key, or passkey, and send it back in the `X-Step-Up`
-  header alongside the deletion. The web path is untouched, a token on its own
-  still gets nowhere, a password-proved elevation is refused for erasure just as
-  a password login never satisfied the gate on the web, and the proof is spent
-  only when the erasure is about to run, so a mistyped confirmation does not
-  burn it. One thing to know when erasing the record over a token: API tokens
-  are part of what that request deletes, so the app signs itself out and has to
-  sign in again.
 - **Anthropic keys work again on current Claude models.** Every JSON surface
   on the Anthropic provider (the daily briefing, the status cards, lab and
   document extraction, anything that asks the model for a JSON object) had

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.2
+  version: 1.38.3
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.2";
+  /* @sw-version-fallback */ "v1.38.3";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Release v1.38.3, both fixes merged since v1.38.2.

- **An account with two-factor can be deleted from the phone** (#888). Apple requires in-app account deletion, and ours refused every native client whose account had a factor enrolled, because the fresh-factor proof lived on the session row. The app now re-proves through the step-up ceremony it already uses for factor management and sends the elevation in a header. The web path is untouched and a token on its own still gets nowhere.
- **Every measurement source is called by its name** (#889). Seven of fourteen sources had no display label, in two catalogues, plus one in the intake history, so a reader saw `GOOGLE_HEALTH` where others said Withings. All seven languages are complete, and a test derives the members from the schema enums so the next provider cannot ship nameless.

**Correction carried in this release:** the account-deletion entry had landed under the v1.38.2 heading in the changelog, but it was merged after that tag and is not in that image. It moves to this section.

Gate on this branch: typecheck, lint (three known warnings), format:check, openapi:check, full unit suite (1935 files), `pnpm build`. All clean.
