### PR TITLE
docs: say thank you where people can see it

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ Next.js 16 (App Router, React Server Components), TypeScript strict, PostgreSQL 
 
 Actively developed — new releases roughly weekly, issue reports and PRs welcome. Behaviour and schema can change between versions; migrations are forward-only.
 
+## Thanks
+
+HealthLog is built in the open and people keep making it better. Alongside
+bug reports, setup questions and the ideas that turned into features, these
+people have sent code that shipped:
+
+<a href="https://github.com/MBombeck/HealthLog/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=MBombeck/HealthLog" alt="Contributors to HealthLog" />
+</a>
+
+Every merged pull request keeps its author's name on the commit, so the
+[contributor graph](https://github.com/MBombeck/HealthLog/graphs/contributors)
+is the full list. Release notes name the people whose work is in that release,
+including anyone who found the defect without sending the fix.
+
 ## License
 
 HealthLog is licensed under the [PolyForm Noncommercial License 1.0.0](LICENSE): free to use, self-host, and modify for noncommercial purposes. Commercial use requires a separate agreement — open an issue or reach out via [healthlog.dev](https://healthlog.dev). Releases up to and including v1.15.18 were published under AGPL-3.0 and remain available under that license.


### PR DESCRIPTION
The contributor graph was already right: every outside author shows up with their contributions, because fork pull requests go in as merge commits and the git authorship survives onto main. Even the two whose pull requests were closed and cherry-picked in June are counted.

What was missing is that nobody reads a graph tab. Someone who sends their first pull request lands on the front page and sees no sign that outside work is part of this project.

So the README says it, and renders the graph inline rather than keeping a hand-written list, because a hand-kept list of names is exactly the thing that goes stale without anyone noticing. It also states the practice: a merged pull request keeps its author's name, and release notes name the people whose work is in that release, including anyone who found a defect without sending the fix.

The avatar strip is rendered by a third-party service, the same class as the four badges already at the top of the file, and GitHub proxies README images so no visitor address reaches that host.
