### PR TITLE
chore(release): v1.38.4 — the shared key finds its provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.4] — 2026-09-02
+
+The shared AI key reaches the provider its address names, and the image
+carries no flagged dependency versions.
 
 ### Fixed
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.3
+  version: 1.38.4
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.3",
+  "version": "1.38.4",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.3";
+  /* @sw-version-fallback */ "v1.38.4";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Release v1.38.4, four changes merged since v1.38.3.

- **The admin AI key reaches the provider its base URL names** (#897). An operator who paired an Anthropic key with Anthropic's base URL got a failure on every call and no hint why, because the request was always built for OpenAI's API. The host now picks the client. Found in a fork by @sweidinger.
- **Seven code-scanning findings closed at their source** (#894). Three stale override floors, and three in the separate npm install inside the image that the project's override block does not reach. The guard meant to hold those two mechanisms in step had been skipping every scoped package name, so it was green because it matched nothing; it can see them now, mutation-checked both ways. A neighbouring test that pinned the literal old version strings would have gone red on any legitimate bump and green on a stale floor; it now compares against the advisory's fixed version.
- **The Dependabot auto-merge workflow no longer hands a write token to the whole run** (#894).
- **Two test races fixed rather than re-run** (#891, #896): a sharing-refusal audit read that outran a deliberately unawaited write, and seven accessibility markers that could match a hidden second copy of a page during a route transition.
- **A visible thank-you on the front page** (#895), because the contributor graph was right but nobody reads a graph tab.

Gate on this branch: typecheck, lint (three known warnings), format:check, openapi:check, full unit suite (1936 files, 22 511 passed), `pnpm build`. All clean. `pnpm audit --prod --audit-level=high` reports no known vulnerabilities.
