### PR TITLE
chore(deps): raise fast-uri and qs override floors past open advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,8 @@ overrides:
   hono@<4.12.25: ^4.12.25
   picomatch@<4.0.4: ^4.0.4
   body-parser@<2.3.0: ^2.3.0
-  fast-uri@<3.1.5: ^3.1.5
+  qs@<6.16.0: ^6.16.0
+  fast-uri@<3.1.6: ^3.1.6
   flatted@<3.4.2: ^3.4.2
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   mysql2@<3.22.0: ^3.22.0
@@ -4557,8 +4558,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6130,8 +6131,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -8564,7 +8565,7 @@ snapshots:
       '@openai/codex-sdk': 0.144.6
       ajv: 8.20.0
       extract-zip: 2.0.1(supports-color@7.2.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       fflate: 0.8.2
       incur: 0.4.13
       papaparse: 5.5.3
@@ -10404,7 +10405,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10640,7 +10641,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -11572,7 +11573,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@7.2.0)
       send: 1.2.1(supports-color@7.2.0)
@@ -11637,7 +11638,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13113,7 +13114,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,19 @@ overrides:
   "hono@<4.12.25": "^4.12.25"
   "picomatch@<4.0.4": "^4.0.4"
   "body-parser@<2.3.0": "^2.3.0"
-  "fast-uri@<3.1.5": "^3.1.5"
+  # Two parser flaws: bracket-key comma parsing walks around `arrayLimit`, and
+  # an attacker-controlled `isBuffer` turns a request body into a hang. The
+  # copy is express 5's, reached through the MCP SDK's HTTP transport, so it
+  # sits on a request path. body-parser asks for ^6.15.2 and express for
+  # ^6.14.0, so 6.16.0 satisfies both without a major.
+  "qs@<6.16.0": "^6.16.0"
+  # Four advisories against the 3.1.x line, all in URI parsing: percent-encoded
+  # scheme normalization and skipped IDN handling let a crafted URL read as a
+  # different host than the one it resolves to, which is exactly the confusion
+  # the SSRF guard in `isPublicUrl` exists to prevent. The copies arrive under
+  # ajv, pulled in by @hookform/resolvers and the MCP SDK. 3.1.6 is the
+  # patched floor and stays on the same minor.
+  "fast-uri@<3.1.6": "^3.1.6"
   "flatted@<3.4.2": "^3.4.2"
   # The advisory covers 4.x only; the bound keeps a hypothetical 3.x consumer
   # off a major it never asked for.


### PR DESCRIPTION
The Dependency Audit job has been failing on every open PR — #892, #893 and #899 all show it red while everything else is green. It is not their fault: `pnpm audit --prod --audit-level=high` is red on `main` too. Six advisories, two transitive packages.

**fast-uri 3.1.5 → 3.1.6** (4× high)
Percent-encoded scheme normalization and skipped IDN handling let a crafted URL read as a different host than the one it actually resolves to — the exact confusion class `isPublicUrl` exists to catch. Both copies arrive under `ajv`, pulled in by `@hookform/resolvers` and the MCP SDK.
GHSA-jqff-g426-hqxp, GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf

**qs 6.15.3 → 6.16.0** (2× moderate)
Bracket-key comma parsing walks around `arrayLimit`, and an attacker-controlled `isBuffer` turns a request body into a hang. This copy is express 5's, reached through the MCP SDK's HTTP transport, so it sits on a request path rather than a build path. `body-parser` asks for `^6.15.2` and `express` for `^6.14.0`, so 6.16.0 satisfies both without a major.
GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g

Both bounds go into `pnpm-workspace.yaml` the same way as the ones already there, with a comment naming the advisory and the path it arrives on. Same minor line in both cases, and the lockfile moves exactly two packages.

## Verification

- `pnpm audit --prod --audit-level=high` → **No known vulnerabilities found** (was: 4 high, 2 moderate)
- `pnpm typecheck` → clean
- `pnpm build` → succeeds, 320 static pages
- `pnpm test` → 22510 passing, 12 skipped. One timing flake in `timezone-explicit-formatter-guard.test.ts` (5s timeout on the grep guard, cold cache on this machine); passes on its own in 5.9s and is unrelated to either package.

Once this is on `main`, rebasing #892/#893/#899 should turn their Dependency Audit green.