### PR TITLE
chore(security): raise two advisory floors that went stale overnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- Two advisory floors raised. A URI parser that arrives under several
+  dependencies, the connector SDK among them, was below the fix for four
+  advisories about host confusion and request forgery through percent-encoded
+  schemes, skipped internationalised-name canonicalisation, and malformed or
+  repeated authorities. A query-string parser was below the fix for an
+  array-limit bypass and a denial of service. Both are pinned past their fixes,
+  and the dependency audit reads clean again.
+
 ## [1.38.4] — 2026-09-02
 
 The shared AI key reaches the provider its address names, and the image

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,8 @@ overrides:
   hono@<4.12.25: ^4.12.25
   picomatch@<4.0.4: ^4.0.4
   body-parser@<2.3.0: ^2.3.0
-  fast-uri@<3.1.5: ^3.1.5
+  qs@<6.16.0: ^6.16.0
+  fast-uri@<3.1.6: ^3.1.6
   flatted@<3.4.2: ^3.4.2
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   mysql2@<3.22.0: ^3.22.0
@@ -4557,8 +4558,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6130,8 +6131,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -8564,7 +8565,7 @@ snapshots:
       '@openai/codex-sdk': 0.144.6
       ajv: 8.20.0
       extract-zip: 2.0.1(supports-color@7.2.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       fflate: 0.8.2
       incur: 0.4.13
       papaparse: 5.5.3
@@ -10404,7 +10405,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10640,7 +10641,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -11572,7 +11573,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@7.2.0)
       send: 1.2.1(supports-color@7.2.0)
@@ -11637,7 +11638,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13113,7 +13114,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,14 @@ overrides:
   "hono@<4.12.25": "^4.12.25"
   "picomatch@<4.0.4": "^4.0.4"
   "body-parser@<2.3.0": "^2.3.0"
-  "fast-uri@<3.1.5": "^3.1.5"
+  # Array-limit bypass through bracket-key comma parsing, and a denial of
+  # service through an attacker-controlled isBuffer. 6.16.0 covers both.
+  "qs@<6.16.0": "^6.16.0"
+  # GHSA-jqff-g426-hqxp and three siblings: host confusion and request
+  # forgery through percent-encoded schemes, skipped IDN canonicalisation and
+  # malformed authorities. It arrives under ajv, including the connector SDK's
+  # copy, so it sits on a path this app exposes.
+  "fast-uri@<3.1.6": "^3.1.6"
   "flatted@<3.4.2": "^3.4.2"
   # The advisory covers 4.x only; the bound keeps a hypothetical 3.x consumer
   # off a major it never asked for.


### PR DESCRIPTION
Six advisories landed overnight and the audit gate went red on every open branch.

Four of them are against a URI parser that arrives under `ajv`, including the copy the connector SDK pulls, so it sits on a path this application exposes: host confusion through percent-encoded schemes, host confusion through skipped internationalised-name canonicalisation, and request forgery through malformed and through repeated authorities. The floor for that package was raised yesterday and was already one patch below the fix. Two more are against a query-string parser: an array-limit bypass through bracket-key comma parsing, and a denial of service through an attacker-controlled buffer check.

Both floors are raised to the advisories' fixed versions, each with the reason written beside it. `pnpm audit --prod` reports no known vulnerabilities after the bump.

Worth noting for its own sake: a floor set one day and stale the next is the argument for pinning to the advisory's fixed version rather than to the version that happens to resolve today. The guard that compares the two override mechanisms was widened for exactly this reason in a parallel branch.
