### PR TITLE
docs(changelog): correct the v1.38.5 backup claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ they say.
   a generous heap, went from dying of memory to finishing in about twenty
   seconds, with a stored copy of 25 MB instead of 322 MB. The pass also has an
   explicit two-hour window now, so a genuinely slow disk cannot be mistaken for
-  a broken run.
+  a broken run. The nightly off-host copy is built the same way and got the
+  same treatment; files written before this still restore, and so do backups
+  already sitting in the database.
 
   **That measurement does not carry to a small container, and this entry
   originally over-claimed from it.** A container capped at 1 GB gives the
@@ -41,9 +43,8 @@ they say.
   Worse, it takes the whole process down with it, so a failed backup becomes an
   outage for everyone else on the instance. Building the record incrementally
   rather than whole is the actual fix and has not landed yet. Until it does, an
-  instance backing up a large record wants more than 1 GB. The nightly off-host copy is
-  built the same way and got the same treatment; files written before this
-  still restore, and so do backups already sitting in the database.
+  instance backing up a large record wants more than 1 GB.
+
 - **A failed backup run is now visible on the backups page.** The weekly pass
   can stop and leave no trace: the page listed whatever copies existed, and a
   copy from six weeks ago carries a timestamp exactly like Sunday's. The page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [1.38.5] — 2026-09-03
 
-The weekly backup finishes again, the dashboard stops scanning the two
-largest tables, and several settings now do what they say.
+The weekly backup costs a fraction of the memory it did, the dashboard
+stops scanning the two largest tables, and several settings now do what
+they say.
 
 ### Security
 
@@ -27,10 +28,20 @@ largest tables, and several settings now do what they say.
   which is four full copies of the record at the same moment. The stored copy
   is now compressed before it is encrypted, which takes an order of magnitude
   off everything after it, and the pass releases each stage before allocating
-  the next. A seeded 445 000-reading account went from dying of memory to
-  finishing in about twenty seconds, with a stored copy of 25 MB instead of
-  322 MB. The pass also has an explicit two-hour window now, so a genuinely
-  slow disk cannot be mistaken for a broken run. The nightly off-host copy is
+  the next. A seeded 445 000-reading account, on a machine with
+  a generous heap, went from dying of memory to finishing in about twenty
+  seconds, with a stored copy of 25 MB instead of 322 MB. The pass also has an
+  explicit two-hour window now, so a genuinely slow disk cannot be mistaken for
+  a broken run.
+
+  **That measurement does not carry to a small container, and this entry
+  originally over-claimed from it.** A container capped at 1 GB gives the
+  runtime a 524 MB heap, and against one of those the pass still runs out of
+  memory, roughly three times further along than before but short of the end.
+  Worse, it takes the whole process down with it, so a failed backup becomes an
+  outage for everyone else on the instance. Building the record incrementally
+  rather than whole is the actual fix and has not landed yet. Until it does, an
+  instance backing up a large record wants more than 1 GB. The nightly off-host copy is
   built the same way and got the same treatment; files written before this
   still restore, and so do backups already sitting in the database.
 - **A failed backup run is now visible on the backups page.** The weekly pass


### PR DESCRIPTION
The v1.38.5 entry said the weekly backup finishes again. That was written from a measurement taken with a multi-gigabyte heap and does not hold on a small container: capped at 1 GB the runtime gets a 524 MB heap, and the pass still runs out of memory there, taking the process down with it.

The improvement is real, roughly three times further along than before, and the entry now describes it as that rather than as a fix. It also says what an operator needs to know: until the record is built incrementally, an instance backing up a large record wants more than 1 GB.

The published release notes carry the same correction.
