### PR TITLE
v1.38.8 — the HRV tile for ring and strap accounts, and a token ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.8] — 2026-09-03
+
+The heart-rate-variability tile now works for accounts whose HRV comes
+from a ring or a strap, and an account can no longer accumulate an
+unbounded pile of measurement tokens. Both from @Antiheld86.
 
 ### Changed
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.7
+  version: 1.38.8
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.7",
+  "version": "1.38.8",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.7";
+  /* @sw-version-fallback */ "v1.38.8";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Two changes from @Antiheld86, both reviewed and merged today.

**The HRV tile never appeared for an account whose variability comes from a ring or a strap.** HRV is stored two ways and the tile looked only for one of them, so the Settings toggle was offered, turned on, and rendered nothing, while the same readings charted fine on the HRV page. It now uses whichever series the account actually has, titled so a 40 ms RMSSD night is not read as a collapsed SDNN figure. Turning the Recovery module off takes RMSSD off the dashboard on every feed now, not only the default one.

**An account can hold ten live measurement tokens.** Past that a mint is refused until one is revoked, so a script stuck in a retry loop meets a wall instead of leaving hundreds of live credentials behind. Session tokens are counted separately and never eat into it.
