### PR TITLE
v1.38.9 — date order everywhere, plain-HTTP writes, gateway errors named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.9] — 2026-09-05
+
+The date order you choose now reaches every date on screen, a plain-HTTP
+self-host can write again, and a gateway that refuses now says why.
 
 ### Fixed
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.8
+  version: 1.38.9
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.8",
+  "version": "1.38.9",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.8";
+  /* @sw-version-fallback */ "v1.38.9";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Three fixes that landed on main today, each from a report.

**The date order you choose reaches every date on screen** (#922). The preference reached the entry form and nothing else, because the formatter took it as an optional argument with a default. The default is gone, every caller carries the preference, and a guard refuses a numeric date renderer that does not.

**A plain-HTTP self-host can write again** (discussion #492). Not just uploads: every write minted its idempotency key with `crypto.randomUUID()`, which the browser withholds from a non-HTTPS page, so on a LAN self-host nothing was saved and nothing said why. A random id that is not gated replaces it, with a guard.

**A gateway that refuses now says why.** OpenRouter returns HTTP 200 with an embedded error on a provider failure; HealthLog reported it as "empty content", status 0. The embedded code and message now surface on the provider health card and in the ledger, for the OpenAI-compatible gateway and the local provider alike.

Each change had its own green run and its own mutation proof before merging; this branch only bumps the version and heads the changelog.
