### PR TITLE
v1.38.10 — the off-host backup streams, the rotated token sunsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [Unreleased]
+## [1.38.10] — 2026-09-06
+
+The nightly off-host backup streams and fits a small container, and a
+busy native client is no longer signed out at the token boundary.
 
 ### Fixed
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: HealthLog API
-  version: 1.38.9
+  version: 1.38.10
   description: >-
     Self-hosted personal-health-tracking PWA — public API surface for the iOS native client and external ingest.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "healthlog",
-  "version": "1.38.9",
+  "version": "1.38.10",
   "description": "Self-hosted personal-health-tracking PWA with Withings integration, AI insights, and doctor-report PDF export.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "homepage": "https://healthlog.dev",

--- a/public/sw.js
+++ b/public/sw.js
@@ -36,7 +36,7 @@ try {
 // v1.4.38.4 → v1.4.42. Do not hand-edit; bump `package.json` and rebuild.
 const CACHE_VERSION =
   (typeof self !== "undefined" && self.__APP_VERSION__) ||
-  /* @sw-version-fallback */ "v1.38.9";
+  /* @sw-version-fallback */ "v1.38.10";
 const STATIC_CACHE = `healthlog-static-${CACHE_VERSION}`;
 const PAGE_CACHE = `healthlog-pages-${CACHE_VERSION}`;
 // v1.18.6 — read-only data cache for a curated allowlist of safe GET `/api/*`


### PR DESCRIPTION
Two changes, each merged today with its own green run and mutation proof; this branch bumps the version and heads the changelog.

**The nightly off-host backup streams** (#927). Its first real run took production down on the heap; the payload now flows table by table through compression, an incremental cipher and a multipart upload, measured under the real ceiling. Older copies still restore. A pass that uploads nothing is a failed job.

**A rotated access token sunsets for fifteen seconds** (#929) instead of being revoked the instant the refresh commits, so a phone with requests in flight is not signed out at the 24-hour mark. Reuse detection and logout still revoke instantly.